### PR TITLE
Fix statusLine hook on spaced paths and Python 3.9 systems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 
+[tool.ruff.lint.per-file-ignores]
+# usag_statusline.py 設計成可以用系統 python3 跑（macOS 內建是 3.9），
+# 必須避開 3.11+ 才有的 datetime.UTC，用 timezone.utc 取代。
+"usag_statusline.py" = ["UP017"]
+
 [tool.mypy]
 python_version = "3.13"
 strict = true

--- a/setup_hook.py
+++ b/setup_hook.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import shlex
 import shutil
 import stat
 import sys
@@ -33,7 +34,7 @@ PREV_SL_KEY = "previousStatusLine"
 def _statusline_command() -> str:
     # 用系統 python3，不綁 venv（hook 只用標準庫）
     python = shutil.which("python3") or "python3"
-    return f"{python} {HOOK_TARGET}"
+    return f"{shlex.quote(python)} {shlex.quote(str(HOOK_TARGET))}"
 
 
 def _is_usag_hook(sl: object) -> bool:

--- a/tests/test_setup_hook.py
+++ b/tests/test_setup_hook.py
@@ -91,3 +91,34 @@ def test_unsetup_without_install_is_safe_and_is_usag_hook_detects_commands(
     assert setup_hook.unsetup() == 0
     assert setup_hook._is_usag_hook({"command": "python3 /tmp/usag-statusline.py"})
     assert not setup_hook._is_usag_hook({"command": "python3 /tmp/other.py"})
+
+
+def test_statusline_command_quotes_paths_with_spaces(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """專案 clone 在含空格的路徑（例如中文資料夾）時，
+    產生的 statusLine command 必須能被 /bin/sh -c 正確解析。"""
+    import shlex
+    import subprocess
+
+    spaced_dir = tmp_path / "claude code小工具"
+    spaced_dir.mkdir()
+    spaced_python = spaced_dir / "python3"
+    spaced_python.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+    spaced_python.chmod(0o755)
+
+    spaced_hook = spaced_dir / "usag-statusline.py"
+    spaced_hook.write_text("import sys; sys.exit(0)\n", encoding="utf-8")
+
+    monkeypatch.setattr(shutil, "which", lambda _: str(spaced_python))
+    monkeypatch.setattr(setup_hook, "HOOK_TARGET", spaced_hook)
+
+    cmd = setup_hook._statusline_command()
+
+    # 兩段路徑都應該被 shlex 安全處理過
+    tokens = shlex.split(cmd)
+    assert tokens == [str(spaced_python), str(spaced_hook)]
+
+    # /bin/sh -c 真的能跑（即不會被空格切碎）
+    result = subprocess.run(["/bin/sh", "-c", cmd], capture_output=True)
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")

--- a/usag_statusline.py
+++ b/usag_statusline.py
@@ -18,7 +18,7 @@ import json
 import os
 import sys
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 __version__ = "1.0"
@@ -57,7 +57,7 @@ def main() -> None:
         return
     if not isinstance(data, dict):
         return
-    save(data, datetime.now(UTC))
+    save(data, datetime.now(timezone.utc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 為什麼這個 PR

我把這個專案 clone 到 `~/Documents/claude code小工具/usage`（中文 + 空格的路徑），跑完 `--setup` 之後 menu bar 永遠顯示 `--`、`~/.claude/usag-status.json` 從來沒被寫出來。Debug 之後發現兩個獨立 bug 疊在一起，這個 PR 同時修。

## Bug 1: `_statusline_command()` 路徑沒 escape

`setup_hook.py:36` 把 interpreter 跟 hook 路徑直接 f-string 拼起來：

```python
return f"{python} {HOOK_TARGET}"
```

Claude Code 接到這個字串會用 `/bin/sh -c` 去跑。當路徑含空格時 shell 會在錯的地方斷詞：

```
$ /bin/sh -c '/Users/<me>/Documents/claude code小工具/usage/.venv/bin/python3 /Users/<me>/.claude/usag-statusline.py'
/bin/sh: /Users/<me>/Documents/claude: is a directory
```

Hook 從未被執行、`usag-status.json` 永遠不會被寫入、menu bar 永遠顯示 `--`，而且**完全 silent**（hook 沒有 log、setup 看起來成功）。

修法：用 `shlex.quote()` 包兩段路徑。

## Bug 2: `usag_statusline.py` 在 macOS 系統 Python (3.9) 直接 ImportError

Hook 第一行 `from datetime import UTC, datetime`，但 `datetime.UTC` 是 Python **3.11+** 才有的別名。

`setup_hook.py` 寫的是「用系統 python3，不綁 venv」（comment 在 line 34），透過 `shutil.which("python3")` 抓 interpreter。但 macOS Sequoia / Sonoma 的 Command Line Tools 內建 `/usr/bin/python3` **還是 Python 3.9.6**，所以 hook 一啟動就：

```
ImportError: cannot import name 'UTC' from 'datetime'
```

跟 Bug 1 一樣，hook 啟動就 crash、`usag-status.json` 永遠不會被寫入，而且使用者完全察覺不到（hook stderr 通常被 Claude Code 吞掉）。

修法：把 `from datetime import UTC, datetime` 改成 `from datetime import datetime, timezone`，使用 `timezone.utc`，相容 Python 3.9+。

因為 repo 的 `ruff` 設 `target-version = "py313"` 會跳 UP017（建議改用 `datetime.UTC`），這跟我們的相容性需求衝突，所以在 `pyproject.toml` 加 per-file ignore，把意圖寫成註解。

## 為什麼這兩個 bug 至今才浮出

* 路徑空格：repo / 使用者把專案放在沒空格的英文路徑時不會中
* Python 3.9：路徑沒空格、又剛好系統有 brew 裝的新 python3 時不會中

兩個只要其一不踩就還是會 work，但同時踩到的人（像我）會花很久才找到 root cause，因為兩邊都 silent fail。

## Verification

* `uv run ruff check .` 全綠
* `uv run mypy .` 全綠（19 files）
* `uv run pytest -v` 61 passed（含本 PR 新加的一個 regression test）
* 手動驗證：
  * 系統 Python 3.9.6 跑 hook 正常 (`exit 0`、status file 有寫)
  * Python 3.13 跑 hook 正常（向後相容）
  * `/bin/sh -c "$cmd"` 對含中文 + 空格的路徑能成功 spawn hook

## Changes

| File | What |
|---|---|
| `setup_hook.py` | 用 `shlex.quote()` 包 statusLine command 兩段路徑 |
| `usag_statusline.py` | `datetime.UTC` → `datetime.timezone.utc` |
| `pyproject.toml` | 加 per-file ruff ignore UP017，附說明 |
| `tests/test_setup_hook.py` | 加一個 regression test：含空格路徑的 statusLine command 能被 `/bin/sh -c` 正確解析 |

40 insertions(+), 3 deletions(-).