### PR TITLE
fix: resolve packaged data files via RESOURCEPATH in py2app bundles

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -1,12 +1,42 @@
 from __future__ import annotations
 
 import json
+import os
 from functools import lru_cache
 from pathlib import Path
 
 from usage_lang import detect_lang
 
-I18N_PATH = Path(__file__).with_name("i18n.json")
+
+def packaged_resource_path(filename: str, source_mode_path: Path) -> Path:
+    """Resolve a data file across source-mode and py2app-bundle layouts.
+
+    py2app declares data files via setup_app.py ``OPTIONS["resources"]`` and
+    copies them to ``Contents/Resources/`` — adjacent to ``lib/python313.zip``,
+    not inside it. py2app injects the ``RESOURCEPATH`` env var at launch
+    pointing at that directory; we prefer it when present.
+
+    Why this exists: in py2app builds this module is compiled into
+    ``lib/python313.zip``, so ``Path(__file__).with_name("i18n.json")``
+    resolves to ``lib/python313.zip/i18n.json`` — an invalid path through
+    the zipfile that raises ``NotADirectoryError`` at first read. In source
+    mode (and tests) ``RESOURCEPATH`` is unset and the source-adjacent
+    fallback path is correct.
+
+    The callers pass the source-mode path explicitly (as the literal
+    ``Path(__file__).with_name("...")``) so that
+    ``tests/test_packaged_resources.py`` can still statically detect every
+    declared resource and enforce that ``setup_app.py`` lists it.
+    """
+    resource_root = os.environ.get("RESOURCEPATH")
+    if resource_root:
+        bundled = Path(resource_root) / filename
+        if bundled.exists():
+            return bundled
+    return source_mode_path
+
+
+I18N_PATH = packaged_resource_path("i18n.json", Path(__file__).with_name("i18n.json"))
 
 
 @lru_cache(maxsize=1)

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from i18n import packaged_resource_path
 from usage_client import ClaudeUsageClient, PollOutcome, PollState
 from usage_lang import detect_lang
 from usage_rate import UsageRateTracker
@@ -54,7 +55,10 @@ def _setup_logging() -> None:
 
 def _i18n_text(language: str, key: str) -> str:
     try:
-        data = json.loads(Path(__file__).with_name("i18n.json").read_text(encoding="utf-8"))
+        i18n_path = packaged_resource_path(
+            "i18n.json", Path(__file__).with_name("i18n.json")
+        )
+        data = json.loads(i18n_path.read_text(encoding="utf-8"))
         table = data.get(language) or data.get("en") or {}
         return str(table.get(key) or data.get("en", {}).get(key) or key)
     except (OSError, json.JSONDecodeError, AttributeError):

--- a/menubar.py
+++ b/menubar.py
@@ -45,7 +45,7 @@ import panels
 import update_checker
 from burn_rate import WARNING_PERCENT_FLOOR, BurnRateTracker
 from history_loader import UsageEntry, load_entries
-from i18n import _t
+from i18n import _t, packaged_resource_path
 from main import _load_preferences, _save_preferences
 from panels.base import Panel as UsagePanel
 from panels.base import load_active_panel_id, save_active_panel_id
@@ -135,7 +135,9 @@ def _current_version() -> str:
     try:
         return metadata.version("usage")
     except metadata.PackageNotFoundError as exc:
-        pyproject = Path(__file__).with_name("pyproject.toml")
+        pyproject = packaged_resource_path(
+            "pyproject.toml", Path(__file__).with_name("pyproject.toml")
+        )
         data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
         version = data.get("project", {}).get("version")
         if isinstance(version, str):

--- a/tests/test_i18n_packaged_path.py
+++ b/tests/test_i18n_packaged_path.py
@@ -1,0 +1,107 @@
+"""Regression tests for ``i18n.packaged_resource_path``.
+
+These cover the fix for the py2app launch crash where
+``Path(__file__).with_name("i18n.json")`` resolved into
+``lib/python313.zip/i18n.json`` and raised ``NotADirectoryError`` at first
+read. The fix prefers the ``RESOURCEPATH`` env var py2app injects at
+launch (pointing at ``Contents/Resources/``) and only falls back to the
+source-adjacent path when running outside a bundle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from i18n import packaged_resource_path
+
+
+def test_prefers_RESOURCEPATH_when_file_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = tmp_path / "Resources"
+    bundle.mkdir()
+    (bundle / "i18n.json").write_text("{}", encoding="utf-8")
+
+    source_path = tmp_path / "source" / "i18n.json"
+    source_path.parent.mkdir()
+    source_path.write_text('{"different": {}}', encoding="utf-8")
+
+    monkeypatch.setenv("RESOURCEPATH", str(bundle))
+    resolved = packaged_resource_path("i18n.json", source_path)
+
+    assert resolved == bundle / "i18n.json"
+
+
+def test_falls_back_to_source_path_when_RESOURCEPATH_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("RESOURCEPATH", raising=False)
+    source_path = tmp_path / "i18n.json"
+    source_path.write_text("{}", encoding="utf-8")
+
+    resolved = packaged_resource_path("i18n.json", source_path)
+    assert resolved == source_path
+
+
+def test_falls_back_when_RESOURCEPATH_set_but_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RESOURCEPATH exists but does not contain the file → fall through."""
+    bundle = tmp_path / "Resources"
+    bundle.mkdir()
+    # deliberately do NOT create bundle/i18n.json
+
+    source_path = tmp_path / "source" / "i18n.json"
+    source_path.parent.mkdir()
+    source_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv("RESOURCEPATH", str(bundle))
+    resolved = packaged_resource_path("i18n.json", source_path)
+
+    assert resolved == source_path
+
+
+def test_falls_back_when_RESOURCEPATH_empty_string(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty RESOURCEPATH is treated as unset (defensive)."""
+    monkeypatch.setenv("RESOURCEPATH", "")
+    source_path = tmp_path / "i18n.json"
+    source_path.write_text("{}", encoding="utf-8")
+
+    resolved = packaged_resource_path("i18n.json", source_path)
+    assert resolved == source_path
+
+
+def test_simulated_py2app_zipfile_path_does_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end repro of the original crash.
+
+    Pre-fix: the source-mode path was the only option, and inside py2app
+    it resolved to ``lib/python313.zip/i18n.json`` — an invalid path through
+    the zipfile that raised ``NotADirectoryError`` on read. This test
+    reconstructs the same shape: a path that points inside a regular file
+    (simulating the zip) and asserts that packaged_resource_path returns
+    the bundled copy instead of the broken zip-internal path.
+    """
+    resources = tmp_path / "Resources"
+    resources.mkdir()
+    (resources / "i18n.json").write_text('{"en": {}}', encoding="utf-8")
+
+    fake_zip = resources / "lib" / "python313.zip"
+    fake_zip.parent.mkdir()
+    fake_zip.write_bytes(b"PK\x05\x06" + b"\x00" * 18)  # minimal empty-zip footer
+    # this is what Path(__file__).with_name resolves to when __file__ is inside the zip
+    crashing_source_path = fake_zip / "i18n.json"
+
+    monkeypatch.setenv("RESOURCEPATH", str(resources))
+    resolved = packaged_resource_path("i18n.json", crashing_source_path)
+
+    # Must NOT return the crashing path
+    assert resolved != crashing_source_path
+    # Must return the real, readable file
+    assert resolved == resources / "i18n.json"
+    assert resolved.read_text() == '{"en": {}}'

--- a/tui.py
+++ b/tui.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from i18n import packaged_resource_path
 from tui_sprite import render_sprite
 from usage_client import PollState, UsageSnapshot
 
@@ -30,7 +31,7 @@ SPINNER_FRAMES = ["·", "✻", "✽", "✶", "✳", "✢"]
 SPINNER_PHASES = [0, 1, 2, 3, 4, 5, 4, 3, 2, 1]
 SPINNER_PHASE_MS = [260, 130, 130, 130, 130, 260, 130, 130, 130, 130]
 LOADING_INTERVAL_MS = 4000
-I18N_PATH = Path(__file__).with_name("i18n.json")
+I18N_PATH = packaged_resource_path("i18n.json", Path(__file__).with_name("i18n.json"))
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Problem

The prebuilt `.app` releases ([v0.10.0](https://github.com/aqua5230/usage/releases/tag/v0.10.0), [v0.10.1](https://github.com/aqua5230/usage/releases/tag/v0.10.1), [v0.11.0](https://github.com/aqua5230/usage/releases/tag/v0.11.0)) crash on first launch with the generic py2app "Launch error" dialog. Running the binary from a terminal shows:

```
Traceback (most recent call last):
  File "/Applications/usage.app/Contents/Resources/__boot__.py", line 130, in <module>
  File "/Applications/usage.app/Contents/Resources/__boot__.py", line 84, in _run
  File "/Applications/usage.app/Contents/Resources/main.py", line 300, in <module>
  File "/Applications/usage.app/Contents/Resources/main.py", line 296, in main
  File "menubar.pyc", line 907, in run_app
  File "menubar.pyc", line 242, in initWithMock_interval_
  File "menubar.pyc", line 932, in _empty_state
  File "menubar.pyc", line 1011, in _missing_row
  File "i18n.pyc", line 22, in _t
  File "i18n.pyc", line 14, in _load_i18n_bundle
  File "pathlib/_local.pyc", line 537, in open
NotADirectoryError: [Errno 20] Not a directory: '/Applications/usage.app/Contents/Resources/lib/python313.zip/i18n.json'
```

Reproduced on macOS Sequoia 15.7.3 / arm64 with both v0.10.1 and v0.11.0.

## Root cause

In py2app builds, `i18n.py` gets compiled into `Contents/Resources/lib/python313.zip` (zipimport), but `i18n.json` is copied to `Contents/Resources/` via `setup_app.py`'s `OPTIONS["resources"]` list. The literal expression `Path(__file__).with_name("i18n.json")` evaluates to `.../python313.zip/i18n.json` — an invalid path *through* the zipfile that raises `NotADirectoryError` on read. Source mode is unaffected because `__file__` resolves to the on-disk module path.

The maintainer's [`test_packaged_resources.py`](https://github.com/aqua5230/usage/blob/main/tests/test_packaged_resources.py) correctly enforces that every `Path(__file__).with_name("...")` reference is declared in `OPTIONS["resources"]`. It is — `i18n.json` is bundled to `Contents/Resources/i18n.json`. The bug is just that the runtime resolution never looks at that location.

## Fix

Add `packaged_resource_path(filename, source_mode_path) -> Path` in `i18n.py` that:

1. Prefers `$RESOURCEPATH/<filename>` (py2app injects `RESOURCEPATH` at launch pointing at `Contents/Resources/`)
2. Falls back to `source_mode_path` when the env var is unset or the bundled copy is missing

Callers pass the literal `Path(__file__).with_name("...")` as `source_mode_path`, so `test_packaged_resources.py`'s AST walker can still statically detect every declared resource:

```python
I18N_PATH = packaged_resource_path(
    "i18n.json", Path(__file__).with_name("i18n.json")
)
```

Applied at all four callsites that read packaged data files:

| File:line | Resource | Effect |
|---|---|---|
| `i18n.py:9` | `i18n.json` | The crash site |
| `tui.py:33` | `i18n.json` | Same pattern — would crash if TUI ever instantiated under py2app |
| `main.py:57` | `i18n.json` | Duplicate read for early-language messages |
| `menubar.py:138` | `pyproject.toml` | Silent fallback path for version lookup; would crash when package metadata absent |

## Tests

New `tests/test_i18n_packaged_path.py` with 5 cases:

- Prefers `RESOURCEPATH` when bundled file exists
- Falls back to source path when `RESOURCEPATH` unset
- Falls back when `RESOURCEPATH` set but file missing
- Falls back on empty-string `RESOURCEPATH`
- **End-to-end repro:** pointing `source_mode_path` *inside* a zip-shaped file (the original crash shape) returns the bundled copy instead

All **187** existing tests still pass. `ruff` and `mypy` clean.

## Manual verification

```bash
git checkout fix/i18n-bundle-path
uv sync --frozen
uv run python main.py
# → menu bar icon appears, popover renders empty-state UI without crashing
```

Before this fix: `Launch error` dialog on every `open /Applications/usage.app`.
After: clean launch, ready to install the Claude Code hook.

## Why this matters

Right now there is no way to use the released `.app` on macOS Sequoia / arm64 — every user who downloads from Releases hits this on first launch. Source mode (`uv run python main.py`) works, but that's not the path the README directs users to.

## Notes for reviewer

- No new files outside `tests/` (helper lives in existing `i18n.py`)
- No changes to `setup_app.py`, `pyproject.toml`, or the build pipeline
- The fallback expression `Path(__file__).with_name(...)` is preserved at every callsite specifically so `test_packaged_resources.py`'s static AST analysis keeps working
- I'm happy to split out the helper to a shared module (`packaged.py` or similar) if you'd prefer a different shape — kept it in `i18n.py` for minimum surface area