### PR TITLE
fix: drop stale auto=True kwarg in usage_cli setup() call

### DIFF
--- a/usage_cli.py
+++ b/usage_cli.py
@@ -382,7 +382,7 @@ def main():
         console.print(f"[dim]{t('detected', agents=', '.join(a.name + ' ✓' for a in agents))}[/dim]")
 
     if not is_setup():
-        setup(auto=True)
+        setup()
     elif needs_update():
         update_hook()
 


### PR DESCRIPTION
## Problem

Running `python3 usage_cli.py report --all` (or any first-run path where the hook isn't installed yet) crashes immediately with:

```
Traceback (most recent call last):
  File "/.../usage_cli.py", line 476, in <module>
    main()
  File "/.../usage_cli.py", line 385, in main
    setup(auto=True)
TypeError: setup() got an unexpected keyword argument 'auto'
```

## Root cause

`usage_cli.py:385` calls `setup(auto=True)`, but `setup_hook.setup()` has signature `setup(force_forwarder: bool = False)` — there is no `auto` parameter. Every other caller in the repo (`main.py`, `menubar.py`, `setup_app.py`) calls `setup()` with no args or with `force_forwarder=True`, so this looks like a stray kwarg left behind during a prior refactor of the `setup_hook` API.

The crash only fires on the auto-setup branch (`if not is_setup():`), which is why users who already had the hook installed wouldn't see it — but anyone running `usage_cli.py` on a fresh machine, or after `unsetup`, hits it on the first command.

## Fix

Drop the bogus kwarg — `setup()` already does the right thing for the auto-install case with no args.

```diff
     if not is_setup():
-        setup(auto=True)
+        setup()
     elif needs_update():
         update_hook()
```