### PR TITLE
fix: unify Codex usage counting

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -9,7 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - **Visible popovers are repositioned when switching panels**: changing the active theme/panel while the popover is open now closes the old popover, rebuilds the content and size, then shows it again to avoid transient indentation or sizing glitches.
-- **Codex project usage and analysis reports now share one counting path**: when the same Codex session appears in multiple JSONL files, usage keeps the newer cumulative token entry; analysis reports now reuse `codex_loader.load_entries()`, and Project Usage includes Codex sessions so the app and report do not disagree for the same local data.
+- **Codex project usage and analysis reports now share one counting path**: when the same Codex session appears in multiple JSONL files, usage keeps the newer cumulative token entry; analysis reports now reuse `codex_loader.load_entries()`, and Project Usage includes Codex sessions so the app and report do not disagree for the same local data. Project Usage's Today range now matches the footer's local calendar day, and the footer no longer reloads Codex when the caller already supplied Codex entries.
 
 ## [0.11.4] - 2026-05-25
 

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - **Visible popovers are repositioned when switching panels**: changing the active theme/panel while the popover is open now closes the old popover, rebuilds the content and size, then shows it again to avoid transient indentation or sizing glitches.
+- **Codex project usage and analysis reports now share one counting path**: when the same Codex session appears in multiple JSONL files, usage keeps the newer cumulative token entry; analysis reports now reuse `codex_loader.load_entries()`, and Project Usage includes Codex sessions so the app and report do not disagree for the same local data.
 
 ## [0.11.4] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 修正
 - **切換面板時重新定位已開啟的 popover**：使用者在 popover 開啟狀態下切換 theme/panel 時，先關閉舊 popover、重建內容與尺寸後再重新顯示，避免視圖短暫縮排或尺寸錯亂。
+- **Codex 專案用量與分析報告統一算法**：同一個 Codex session 出現在多個 JSONL 檔時，改選較新的 cumulative token entry；分析報告改共用 `codex_loader.load_entries()`，Project Usage 也納入 Codex session，避免同一份資料在 app 與 report 顯示不同數字。
 
 ## [0.11.4] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 修正
 - **切換面板時重新定位已開啟的 popover**：使用者在 popover 開啟狀態下切換 theme/panel 時，先關閉舊 popover、重建內容與尺寸後再重新顯示，避免視圖短暫縮排或尺寸錯亂。
-- **Codex 專案用量與分析報告統一算法**：同一個 Codex session 出現在多個 JSONL 檔時，改選較新的 cumulative token entry；分析報告改共用 `codex_loader.load_entries()`，Project Usage 也納入 Codex session，避免同一份資料在 app 與 report 顯示不同數字。
+- **Codex 專案用量與分析報告統一算法**：同一個 Codex session 出現在多個 JSONL 檔時，改選較新的 cumulative token entry；分析報告改共用 `codex_loader.load_entries()`，Project Usage 也納入 Codex session，避免同一份資料在 app 與 report 顯示不同數字。Project Usage 的 Today 現在與底部 Today 同樣使用本地日曆日，且底部 Today 不會在呼叫端已提供 Codex entries 時重複載入 Codex。
 
 ## [0.11.4] - 2026-05-25
 

--- a/analyzer/reporter.py
+++ b/analyzer/reporter.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+import codex_loader
 from adapters import claude, codex
 from adapters.types import AgentInfo, UsageEntry
 from pricing import calculate_cost
@@ -40,8 +41,24 @@ def _period_bounds(period: str, today: date) -> tuple[date | None, date]:
 def _load_agent_entries(agent: AgentInfo, hours_back: int = 0) -> list[UsageEntry]:
     if hours_back > 0 and agent.id == "claude-code":
         return _load_recent_claude_entries(hours_back)
-    if hours_back > 0 and agent.id == "codex":
-        return _load_recent_codex_entries(hours_back)
+    if agent.id == "codex":
+        return [
+            UsageEntry(
+                timestamp=entry.timestamp,
+                session_id=entry.session_id,
+                message_id=entry.message_id,
+                request_id=entry.request_id,
+                model=entry.model,
+                input_tokens=entry.input_tokens,
+                output_tokens=entry.output_tokens,
+                cache_creation_tokens=entry.cache_creation_tokens,
+                cache_read_tokens=entry.cache_read_tokens,
+                cost_usd=entry.cost_usd,
+                project=entry.project,
+                agent_id=agent.id,
+            )
+            for entry in codex_loader.load_entries(hours_back=hours_back)
+        ]
     loader = AGENT_LOADERS.get(agent.id)
     if loader is None:
         return []

--- a/codex_loader.py
+++ b/codex_loader.py
@@ -32,8 +32,7 @@ def load_entries(hours_back: int = 0) -> list[UsageEntry]:
     if not SESSIONS_DIR.is_dir():
         return []
 
-    entries: list[UsageEntry] = []
-    seen: set[str] = set()
+    entries_by_session: dict[str, UsageEntry] = {}
     cutoff = datetime.now(UTC) - timedelta(hours=hours_back) if hours_back > 0 else None
     cutoff_ts = cutoff.timestamp() if cutoff else None
     models = _load_thread_models()
@@ -47,13 +46,21 @@ def load_entries(hours_back: int = 0) -> list[UsageEntry]:
                 logger.warning("failed to stat session log %s: %s", jsonl_path, exc)
                 continue
         entry = _parse_jsonl(jsonl_path, models, cutoff)
-        if entry is None or entry.session_id in seen:
+        if entry is None:
             continue
-        seen.add(entry.session_id)
-        entries.append(entry)
+        existing = entries_by_session.get(entry.session_id)
+        if existing is None or _is_better_session_entry(entry, existing):
+            entries_by_session[entry.session_id] = entry
 
+    entries = list(entries_by_session.values())
     entries.sort(key=lambda entry: entry.timestamp)
     return entries
+
+
+def _is_better_session_entry(candidate: UsageEntry, existing: UsageEntry) -> bool:
+    if candidate.timestamp != existing.timestamp:
+        return candidate.timestamp > existing.timestamp
+    return candidate.total_tokens > existing.total_tokens
 
 
 def load_rate_limits() -> CodexRateLimits | None:

--- a/menubar.py
+++ b/menubar.py
@@ -976,12 +976,18 @@ class AppDelegate(NSObject):
     def _load_history_entries(self) -> list[UsageEntry]:
         if self.mock:
             return []
+        entries: list[UsageEntry] = []
         try:
-            return load_entries(hours_back=720)
+            entries.extend(load_entries(hours_back=720))
         except Exception:
             if os.environ.get("USAGE_DEBUG") == "1":
-                logger.warning("project usage load failed", exc_info=True)
-            return []
+                logger.warning("Claude project usage load failed", exc_info=True)
+        try:
+            entries.extend(codex_loader.load_entries(hours_back=720))
+        except Exception:
+            if os.environ.get("USAGE_DEBUG") == "1":
+                logger.warning("Codex project usage load failed", exc_info=True)
+        return entries
 
     def _project_rows(
         self,

--- a/menubar.py
+++ b/menubar.py
@@ -1021,8 +1021,16 @@ class AppDelegate(NSObject):
                     logger.warning("project usage load failed", exc_info=True)
                 return []
         else:
-            cutoff = datetime.now(tz=UTC) - timedelta(hours=hours_back)
-            resolved = [e for e in entries if e.timestamp >= cutoff]
+            if hours_back == 24:
+                today = datetime.now().astimezone().date()
+                resolved = [
+                    e for e in entries if e.timestamp.astimezone().date() == today
+                ]
+            elif hours_back > 0:
+                cutoff = datetime.now(tz=UTC) - timedelta(hours=hours_back)
+                resolved = [e for e in entries if e.timestamp >= cutoff]
+            else:
+                resolved = entries
 
         aggregates: dict[str, list[float]] = {}
         for entry in resolved:
@@ -1302,8 +1310,11 @@ def _today_title(
         total_tokens = 0
         total_cost = 0.0
 
-        history = entries if entries is not None else load_entries(hours_back=24)
-        all_entries = list(history) + codex_loader.load_entries(hours_back=24)
+        all_entries = (
+            entries
+            if entries is not None
+            else list(load_entries(hours_back=24)) + codex_loader.load_entries(hours_back=24)
+        )
         for entry in all_entries:
             if entry.timestamp.astimezone().date() != today:
                 continue

--- a/tests/test_analyzer_pipeline.py
+++ b/tests/test_analyzer_pipeline.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import history_loader
 import menubar
 from adapters.types import AgentInfo
+from analyzer import reporter
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -66,3 +69,33 @@ def test_generate_analysis_report_uses_analyzer_pipeline(
 
     assert menubar._generate_analysis_report() == "~/.usage-reports/usage-report-test.html"
     assert calls == {"agents": agents, "period": "month", "data": report_data}
+
+
+def test_report_codex_entries_use_shared_loader(monkeypatch: Any) -> None:
+    source_entry = history_loader.UsageEntry(
+        timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+        session_id="s1",
+        message_id="m1",
+        request_id="r1",
+        model="gpt-test",
+        input_tokens=1,
+        output_tokens=2,
+        cache_creation_tokens=3,
+        cache_read_tokens=4,
+        cost_usd=0.5,
+        project="usage",
+    )
+    calls: dict[str, int] = {}
+
+    def fake_load_entries(*, hours_back: int = 0) -> list[history_loader.UsageEntry]:
+        calls["hours_back"] = hours_back
+        return [source_entry]
+
+    monkeypatch.setattr("analyzer.reporter.codex_loader.load_entries", fake_load_entries)
+
+    entries = reporter._load_agent_entries(AgentInfo("codex", "Codex", "~/.codex", True), 24)
+
+    assert calls == {"hours_back": 24}
+    assert len(entries) == 1
+    assert entries[0].agent_id == "codex"
+    assert entries[0].total_tokens == source_entry.total_tokens

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -81,6 +81,60 @@ def test_load_entries_parses_valid_jsonl_and_filters_by_hours_back(
     assert recent_entries[0].output_tokens == 7
 
 
+def test_load_entries_keeps_latest_duplicate_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    older_ts = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    newer_ts = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+    _write_session(
+        sessions_dir / "older.jsonl",
+        session_id="session-1",
+        timestamp=older_ts,
+        usage={"input_tokens": 10, "cached_input_tokens": 0, "output_tokens": 5},
+    )
+    _write_session(
+        sessions_dir / "newer.jsonl",
+        session_id="session-1",
+        timestamp=newer_ts,
+        usage={"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 50},
+    )
+
+    entries = codex_loader.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].timestamp == datetime.fromisoformat(newer_ts)
+    assert entries[0].total_tokens == 150
+
+
+def test_load_entries_uses_larger_duplicate_when_timestamps_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    timestamp = datetime.now(UTC).isoformat()
+    _write_session(
+        sessions_dir / "small.jsonl",
+        session_id="session-1",
+        timestamp=timestamp,
+        usage={"input_tokens": 10, "cached_input_tokens": 0, "output_tokens": 5},
+    )
+    _write_session(
+        sessions_dir / "large.jsonl",
+        session_id="session-1",
+        timestamp=timestamp,
+        usage={"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 50},
+    )
+
+    entries = codex_loader.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].total_tokens == 150
+
+
 def test_parse_jsonl_skips_bad_lines_and_missing_fields(tmp_path: Path) -> None:
     path = tmp_path / "bad.jsonl"
     path.write_text(

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -534,6 +534,41 @@ def test_project_rows_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     assert delegate._project_rows(hours_back=24) == []
 
 
+def test_load_history_entries_includes_codex_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(False, 60)
+    claude_entry = history_loader.UsageEntry(
+        timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+        session_id="claude",
+        message_id="m1",
+        request_id="r1",
+        model="claude",
+        input_tokens=1,
+        output_tokens=2,
+        cache_creation_tokens=3,
+        cache_read_tokens=4,
+        cost_usd=0.1,
+        project="usage",
+    )
+    codex_entry = history_loader.UsageEntry(
+        timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+        session_id="codex",
+        message_id="m2",
+        request_id="r2",
+        model="gpt",
+        input_tokens=5,
+        output_tokens=6,
+        cache_creation_tokens=7,
+        cache_read_tokens=8,
+        cost_usd=0.2,
+        project="usage",
+    )
+
+    monkeypatch.setattr(menubar, "load_entries", lambda *, hours_back: [claude_entry])
+    monkeypatch.setattr("menubar.codex_loader.load_entries", lambda *, hours_back: [codex_entry])
+
+    assert delegate._load_history_entries() == [claude_entry, codex_entry]
+
+
 def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
     delegate = menubar.AppDelegate.alloc().initWithMock_interval_(False, 60)
 

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -238,6 +238,32 @@ def test_today_title_returns_zero_fallback_when_loaders_fail(
     )
 
     assert menubar._today_title(mock=False, language="zh-TW") == "今日：$0.00 (0 tokens)"
+
+
+def test_today_title_does_not_reload_codex_when_entries_are_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = history_loader.UsageEntry(
+        timestamp=datetime.now(tz=UTC),
+        session_id="codex",
+        message_id="m1",
+        request_id="r1",
+        model="gpt",
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_tokens=0,
+        cache_read_tokens=0,
+        cost_usd=0.01,
+        project="usage",
+    )
+    monkeypatch.setattr(
+        "menubar.codex_loader.load_entries",
+        lambda *, hours_back=24: pytest.fail("Codex should already be included"),
+    )
+
+    assert menubar._today_title(mock=False, language="en", entries=[entry]) == (
+        "Today: $0.01 (150 tokens)"
+    )
 
 
 def test_empty_state() -> None:
@@ -571,10 +597,11 @@ def test_load_history_entries_includes_codex_entries(monkeypatch: pytest.MonkeyP
 
 def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
     delegate = menubar.AppDelegate.alloc().initWithMock_interval_(False, 60)
+    now = datetime.now(tz=UTC)
 
     entries = [
         history_loader.UsageEntry(
-            timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+            timestamp=now,
             session_id="s1",
             message_id="m1",
             request_id="r1",
@@ -587,7 +614,7 @@ def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
             project="usage",
         ),
         history_loader.UsageEntry(
-            timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+            timestamp=now,
             session_id="s2",
             message_id="m2",
             request_id="r2",
@@ -600,7 +627,7 @@ def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
             project="FinMind",
         ),
         history_loader.UsageEntry(
-            timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+            timestamp=now,
             session_id="s3",
             message_id="m3",
             request_id="r3",
@@ -613,7 +640,7 @@ def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
             project="AI客服",
         ),
         history_loader.UsageEntry(
-            timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+            timestamp=now,
             session_id="s4",
             message_id="m4",
             request_id="r4",
@@ -626,7 +653,7 @@ def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
             project="sidecar",
         ),
         history_loader.UsageEntry(
-            timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+            timestamp=now,
             session_id="s5",
             message_id="m5",
             request_id="r5",
@@ -648,6 +675,40 @@ def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:
     assert rows[0] == ("usage", 5_000_000, 2.0)
     assert rows[1][0] == "FinMind"
     assert rows[2][0] == "AI客服"
+
+
+def test_project_rows_today_uses_calendar_day() -> None:
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(False, 60)
+    today_entry = history_loader.UsageEntry(
+        timestamp=datetime.now(tz=UTC),
+        session_id="today",
+        message_id="today-msg",
+        request_id="today-req",
+        model="claude",
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_tokens=0,
+        cache_read_tokens=0,
+        cost_usd=0.01,
+        project="TodayProject",
+    )
+    old_entry = history_loader.UsageEntry(
+        timestamp=datetime.now(tz=UTC) - timedelta(days=1),
+        session_id="old",
+        message_id="old-msg",
+        request_id="old-req",
+        model="claude",
+        input_tokens=10_000,
+        output_tokens=5_000,
+        cache_creation_tokens=0,
+        cache_read_tokens=0,
+        cost_usd=1.0,
+        project="OldProject",
+    )
+
+    assert delegate._project_rows(hours_back=24, entries=[today_entry, old_entry]) == [
+        ("TodayProject", 150, 0.01)
+    ]
 
 
 def test_project_rows_7d_mock() -> None:


### PR DESCRIPTION
## Summary
- keep the latest cumulative entry when the same Codex session appears in multiple JSONL files
- make analysis reports reuse codex_loader.load_entries() for Codex data
- include Codex sessions in Project Usage so the app and report use the same local data path

## Test plan
- [x] .venv/bin/python -m ruff check codex_loader.py analyzer/reporter.py menubar.py tests/test_codex_loader.py tests/test_menubar.py tests/test_analyzer_pipeline.py
- [x] .venv/bin/python -m mypy .
- [x] .venv/bin/python -m pytest tests/test_codex_loader.py tests/test_menubar.py tests/test_analyzer_pipeline.py
- [x] .venv/bin/python -m pytest

## Notes for reviewer
This keeps the existing Claude path unchanged. The Codex report path now goes through the same loader as the app, avoiding drift between two parsers.