### PR TITLE
fix: bucket Codex usage by token_count deltas

### DIFF
--- a/analyzer/reporter.py
+++ b/analyzer/reporter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
@@ -49,23 +48,7 @@ def _load_agent_entries(
     if agent.id == "codex" and use_recent_codex and hours_back > 0:
         return _load_recent_codex_entries(hours_back)
     if agent.id == "codex":
-        return [
-            UsageEntry(
-                timestamp=entry.timestamp,
-                session_id=entry.session_id,
-                message_id=entry.message_id,
-                request_id=entry.request_id,
-                model=entry.model,
-                input_tokens=entry.input_tokens,
-                output_tokens=entry.output_tokens,
-                cache_creation_tokens=entry.cache_creation_tokens,
-                cache_read_tokens=entry.cache_read_tokens,
-                cost_usd=entry.cost_usd,
-                project=entry.project,
-                agent_id=agent.id,
-            )
-            for entry in codex_loader.load_entries(hours_back=hours_back)
-        ]
+        return _load_codex_entries(hours_back)
     loader = AGENT_LOADERS.get(agent.id)
     if loader is None:
         return []
@@ -113,140 +96,28 @@ def _parse_claude_file(path: Path, base: Path, cutoff: datetime) -> list[UsageEn
 
 
 def _load_recent_codex_entries(hours_back: int) -> list[UsageEntry]:
-    entries: list[UsageEntry] = []
-    seen: set[str] = set()
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours_back)
-    cutoff_ts = cutoff.timestamp()
-    models = codex._load_thread_models()  # type: ignore[attr-defined]
-    sessions_path = Path(codex.SESSIONS_DIR)
-    if not sessions_path.is_dir():
-        return entries
-    jobs: list[Path] = []
-    for jsonl_path in sessions_path.rglob("*.jsonl"):
-        try:
-            if jsonl_path.stat().st_mtime < cutoff_ts:
-                continue
-        except OSError:
-            continue
-        jobs.append(jsonl_path)
-    with ThreadPoolExecutor(max_workers=8) as executor:
-        results = executor.map(lambda path: _parse_codex_file(path, models, cutoff), jobs)
-        for parsed in results:
-            for entry in parsed:
-                if entry.dedup_key in seen:
-                    continue
-                seen.add(entry.dedup_key)
-                entries.append(entry)
-    entries.sort(key=lambda entry: entry.timestamp)
-    return entries
+    return _load_codex_entries(hours_back)
 
 
-def _parse_codex_file(path: Path, models: dict[str, str], cutoff: datetime) -> list[UsageEntry]:
-    try:
-        with path.open("rb") as f:
-            head = f.read(64 * 1024)
-    except (OSError, PermissionError):
-        return []
-
-    session_id = ""
-    session_ts = ""
-    project = "unknown"
-    for raw_line in head.splitlines()[:12]:
-        if b"session_meta" not in raw_line:
-            continue
-        try:
-            data = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
-        payload = data.get("payload", {})
-        session_id = payload.get("id", "")
-        session_ts = payload.get("timestamp", "")
-        cwd = payload.get("cwd", "")
-        if cwd:
-            project = codex._project_from_cwd(cwd)  # type: ignore[attr-defined]
-        break
-
-    if not session_id:
-        return []
-
-    try:
-        ts = datetime.fromisoformat(session_ts.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        return []
-    if ts < cutoff:
-        return []
-
-    raw_usage_line = _read_last_matching_line(path, b"token_count", b"total_token_usage")
-    if raw_usage_line is None:
-        return []
-    try:
-        data = json.loads(raw_usage_line)
-    except json.JSONDecodeError:
-        return []
-    payload = data.get("payload", {})
-    info = payload.get("info")
-    last_usage = info.get("total_token_usage") if info else None
-    if not last_usage:
-        return []
-
-    cached = last_usage.get("cached_input_tokens", 0)
-    input_tokens = last_usage.get("input_tokens", 0) - cached
-    output_tokens = last_usage.get("output_tokens", 0) + last_usage.get("reasoning_output_tokens", 0)
-    if input_tokens == 0 and output_tokens == 0:
-        return []
-
-    return [UsageEntry(
-        timestamp=ts,
-        session_id=session_id,
-        message_id=session_id,
-        request_id="",
-        model=models.get(session_id, "unknown"),
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_creation_tokens=0,
-        cache_read_tokens=cached,
-        cost_usd=None,
-        project=project,
-        agent_id="codex",
-        message_count=_count_token_events(path),
-    )]
-
-
-def _count_token_events(path: Path) -> int:
-    count = 0
-    try:
-        with path.open("rb") as f:
-            while True:
-                chunk = f.read(1024 * 1024)
-                if not chunk:
-                    break
-                count += chunk.count(b'"token_count"')
-    except (OSError, PermissionError):
-        return 1
-    return max(1, count)
-
-
-def _read_last_matching_line(path: Path, needle_a: bytes, needle_b: bytes) -> bytes | None:
-    chunk_size = 64 * 1024
-    try:
-        with path.open("rb") as f:
-            f.seek(0, 2)
-            pos = f.tell()
-            tail = b""
-            while pos > 0:
-                read_size = min(chunk_size, pos)
-                pos -= read_size
-                f.seek(pos)
-                data = f.read(read_size) + tail
-                lines = data.splitlines()
-                tail = lines[0] if pos > 0 and lines else b""
-                search_lines = lines[1:] if pos > 0 else lines
-                for raw_line in reversed(search_lines):
-                    if needle_a in raw_line and needle_b in raw_line:
-                        return raw_line
-    except (OSError, PermissionError):
-        return None
-    return None
+def _load_codex_entries(hours_back: int) -> list[UsageEntry]:
+    return [
+        UsageEntry(
+            timestamp=entry.timestamp,
+            session_id=entry.session_id,
+            message_id=entry.message_id,
+            request_id=entry.request_id,
+            model=entry.model,
+            input_tokens=entry.input_tokens,
+            output_tokens=entry.output_tokens,
+            cache_creation_tokens=entry.cache_creation_tokens,
+            cache_read_tokens=entry.cache_read_tokens,
+            cost_usd=entry.cost_usd,
+            project=entry.project,
+            agent_id="codex",
+            message_count=getattr(entry, "message_count", 1),
+        )
+        for entry in codex_loader.load_entries(hours_back=hours_back)
+    ]
 
 
 def _pct(value: int, total: int) -> float:

--- a/codex_loader.py
+++ b/codex_loader.py
@@ -14,7 +14,7 @@ from project_resolver import resolve_project_name
 
 logger = logging.getLogger(__name__)
 
-_jsonl_cache: dict[Path, tuple[float, int, UsageEntry | None]] = {}
+_jsonl_cache: dict[Path, tuple[float, int, list[UsageEntry]]] = {}
 
 SESSIONS_DIR = Path(os.path.expanduser("~/.codex/sessions"))
 STATE_DB = Path(os.path.expanduser("~/.codex/state_5.sqlite"))
@@ -34,7 +34,7 @@ def load_entries(hours_back: int = 0) -> list[UsageEntry]:
     if not SESSIONS_DIR.is_dir():
         return []
 
-    entries_by_session: dict[str, UsageEntry] = {}
+    entries_by_session: dict[str, list[UsageEntry]] = {}
     cutoff = datetime.now(UTC) - timedelta(hours=hours_back) if hours_back > 0 else None
     cutoff_ts = cutoff.timestamp() if cutoff else None
     models = _load_thread_models()
@@ -47,22 +47,32 @@ def load_entries(hours_back: int = 0) -> list[UsageEntry]:
             except OSError as exc:
                 logger.warning("failed to stat session log %s: %s", jsonl_path, exc)
                 continue
-        entry = _parse_jsonl(jsonl_path, models, cutoff)
-        if entry is None:
+        parsed = _parse_jsonl(jsonl_path, models, cutoff)
+        if not parsed:
             continue
-        existing = entries_by_session.get(entry.session_id)
-        if existing is None or _is_better_session_entry(entry, existing):
-            entries_by_session[entry.session_id] = entry
+        existing = entries_by_session.get(parsed[0].session_id)
+        if existing is None or _is_better_session_log(parsed, existing):
+            entries_by_session[parsed[0].session_id] = parsed
 
-    entries = list(entries_by_session.values())
+    entries = [
+        entry
+        for session_entries in entries_by_session.values()
+        for entry in session_entries
+    ]
     entries.sort(key=lambda entry: entry.timestamp)
     return entries
 
 
-def _is_better_session_entry(candidate: UsageEntry, existing: UsageEntry) -> bool:
-    if candidate.timestamp != existing.timestamp:
-        return candidate.timestamp > existing.timestamp
-    return candidate.total_tokens > existing.total_tokens
+def _is_better_session_log(candidate: list[UsageEntry], existing: list[UsageEntry]) -> bool:
+    candidate_latest = candidate[-1]
+    existing_latest = existing[-1]
+    if candidate_latest.timestamp != existing_latest.timestamp:
+        return candidate_latest.timestamp > existing_latest.timestamp
+    return _session_total_tokens(candidate) > _session_total_tokens(existing)
+
+
+def _session_total_tokens(entries: list[UsageEntry]) -> int:
+    return sum(entry.total_tokens for entry in entries)
 
 
 def load_rate_limits() -> CodexRateLimits | None:
@@ -155,27 +165,28 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> CodexRateLimits 
     )
 
 
-def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) -> UsageEntry | None:
+def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) -> list[UsageEntry]:
     try:
         st = path.stat()
     except OSError as exc:
         logger.warning("failed to parse codex session %s: %s", path, exc)
-        return None
+        return []
 
     cache_entry = _jsonl_cache.get(path)
     if cache_entry is not None and cache_entry[0] == st.st_mtime and cache_entry[1] == st.st_size:
-        entry = cache_entry[2]
-        if entry is not None:
+        cached_entries = cache_entry[2]
+        for entry in cached_entries:
             entry.model = models.get(entry.session_id, "unknown")
-            if cutoff is not None and entry.timestamp < cutoff:
-                return None
-        return entry
+        if cutoff is None:
+            return cached_entries
+        return [entry for entry in cached_entries if entry.timestamp >= cutoff]
 
     session_id = ""
     session_timestamp = ""
     project = "unknown"
-    last_usage: dict[str, Any] | None = None
-    last_usage_timestamp = ""
+    entries: list[UsageEntry] = []
+    previous_usage: _TokenUsage | None = None
+    token_count_index = 0
     try:
         with path.open(encoding="utf-8") as file:
             for line in file:
@@ -194,42 +205,74 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
                 if payload.get("type") != "token_count":
                     continue
                 usage = _as_dict(_as_dict(payload.get("info")).get("total_token_usage"))
-                if usage:
-                    last_usage = usage
-                    last_usage_timestamp = _as_str(data.get("timestamp"))
+                timestamp = _parse_timestamp(_as_str(data.get("timestamp")))
+                if not usage or not session_id or timestamp is None:
+                    continue
+                current_usage = _token_usage_from_payload(usage)
+                delta = current_usage.delta(previous_usage)
+                previous_usage = current_usage
+                if delta.total_tokens == 0:
+                    continue
+                token_count_index += 1
+                entries.append(
+                    UsageEntry(
+                        timestamp=timestamp,
+                        session_id=session_id,
+                        message_id=f"{session_id}:{token_count_index}",
+                        request_id="",
+                        model=models.get(session_id, "unknown"),
+                        input_tokens=delta.input_tokens,
+                        output_tokens=delta.output_tokens,
+                        cache_creation_tokens=0,
+                        cache_read_tokens=delta.cache_read_tokens,
+                        cost_usd=None,
+                        project=project,
+                    )
+                )
     except OSError as exc:
         logger.warning("failed to parse codex session %s: %s", path, exc)
-        _jsonl_cache[path] = (st.st_mtime, st.st_size, None)
-        return None
-    timestamp = _parse_timestamp(last_usage_timestamp) or _parse_timestamp(session_timestamp)
-    if not session_id or last_usage is None or timestamp is None:
-        _jsonl_cache[path] = (st.st_mtime, st.st_size, None)
-        return None
-    cached = _as_int(last_usage.get("cached_input_tokens"))
-    input_tokens = max(0, _as_int(last_usage.get("input_tokens")) - cached)
-    output_tokens = _as_int(last_usage.get("output_tokens")) + _as_int(
-        last_usage.get("reasoning_output_tokens"),
+        _jsonl_cache[path] = (st.st_mtime, st.st_size, [])
+        return []
+    if not entries and session_timestamp:
+        _jsonl_cache[path] = (st.st_mtime, st.st_size, [])
+        return []
+    _jsonl_cache[path] = (st.st_mtime, st.st_size, entries)
+    if cutoff is not None:
+        return [entry for entry in entries if entry.timestamp >= cutoff]
+    return entries
+
+
+@dataclass(frozen=True, slots=True)
+class _TokenUsage:
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens + self.cache_read_tokens
+
+    def delta(self, previous: _TokenUsage | None) -> _TokenUsage:
+        if previous is None:
+            return self
+        return _TokenUsage(
+            input_tokens=max(0, self.input_tokens - previous.input_tokens),
+            output_tokens=max(0, self.output_tokens - previous.output_tokens),
+            cache_read_tokens=max(0, self.cache_read_tokens - previous.cache_read_tokens),
+        )
+
+
+def _token_usage_from_payload(usage: dict[str, Any]) -> _TokenUsage:
+    cached = _as_int(usage.get("cached_input_tokens"))
+    input_tokens = max(0, _as_int(usage.get("input_tokens")) - cached)
+    output_tokens = _as_int(usage.get("output_tokens")) + _as_int(
+        usage.get("reasoning_output_tokens"),
     )
-    if input_tokens == 0 and output_tokens == 0:
-        _jsonl_cache[path] = (st.st_mtime, st.st_size, None)
-        return None
-    entry = UsageEntry(
-        timestamp=timestamp,
-        session_id=session_id,
-        message_id=session_id,
-        request_id="",
-        model=models.get(session_id, "unknown"),
+    return _TokenUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
-        cache_creation_tokens=0,
         cache_read_tokens=cached,
-        cost_usd=None,
-        project=project,
     )
-    _jsonl_cache[path] = (st.st_mtime, st.st_size, entry)
-    if cutoff is not None and entry.timestamp < cutoff:
-        return None
-    return entry
 
 
 def _load_json_line(line: str) -> dict[str, Any] | None:

--- a/tests/test_analyzer_pipeline.py
+++ b/tests/test_analyzer_pipeline.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import codex_loader
 import history_loader
 import menubar
 from adapters.types import AgentInfo
@@ -171,21 +172,76 @@ def test_report_short_periods_use_recent_codex_loader(monkeypatch: Any) -> None:
     )
     calls: dict[str, int] = {}
 
-    def fake_recent(hours_back: int) -> list[reporter.UsageEntry]:
-        calls["recent_hours_back"] = hours_back
+    def fake_load_entries(*, hours_back: int = 0) -> list[history_loader.UsageEntry]:
+        calls["hours_back"] = hours_back
         return [recent_entry]
 
-    def fake_full(*, hours_back: int = 0) -> list[history_loader.UsageEntry]:
-        calls["full_hours_back"] = hours_back
-        return []
-
-    monkeypatch.setattr(reporter, "_load_recent_codex_entries", fake_recent)
-    monkeypatch.setattr("analyzer.reporter.codex_loader.load_entries", fake_full)
+    monkeypatch.setattr("analyzer.reporter.codex_loader.load_entries", fake_load_entries)
 
     data = reporter.build_report_data([agent], "today")
 
     assert data["summary"]["total_tokens"] == 3
-    assert calls == {"recent_hours_back": 48}
+    assert calls == {"hours_back": 48}
+
+
+def test_report_today_uses_codex_token_count_deltas(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    codex_loader._jsonl_cache.clear()
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {"session-1": "gpt-test"})
+    now = datetime.now().astimezone()
+    yesterday = now - timedelta(days=1)
+    lines = [
+        {
+            "type": "session_meta",
+            "payload": {
+                "id": "session-1",
+                "timestamp": yesterday.isoformat(),
+                "cwd": "/tmp/usage",
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": yesterday.isoformat(),
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 100,
+                        "cached_input_tokens": 10,
+                        "output_tokens": 20,
+                    }
+                },
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": now.isoformat(),
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 150,
+                        "cached_input_tokens": 15,
+                        "output_tokens": 35,
+                    }
+                },
+            },
+        },
+    ]
+    path = sessions_dir / "session-1.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+    data = reporter.build_report_data(
+        [AgentInfo("codex", "Codex", "~/.codex", True)],
+        "today",
+    )
+
+    assert data["summary"]["total_tokens"] == 65
 
 
 def test_report_last30_keeps_full_codex_loader(monkeypatch: Any) -> None:

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -37,6 +37,31 @@ def _write_session(
     path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
 
 
+def _write_session_with_usage_events(
+    path: Path,
+    *,
+    session_id: str,
+    events: list[tuple[str, dict[str, int]]],
+    cwd: str = "/tmp/demo",
+) -> None:
+    lines = [
+        {
+            "type": "session_meta",
+            "payload": {"id": session_id, "timestamp": events[0][0], "cwd": cwd},
+        },
+    ]
+    lines.extend(
+        {
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": {"type": "token_count", "info": {"total_token_usage": usage}},
+        }
+        for timestamp, usage in events
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+
 def test_load_entries_returns_empty_list_when_sessions_dir_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -87,29 +112,29 @@ def test_load_entries_keeps_latest_duplicate_session(
     sessions_dir = tmp_path / "sessions"
     monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
     monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
-    older_ts = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
-    newer_ts = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+    older_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    newer_ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
     _write_session(
-        sessions_dir / "older.jsonl",
-        session_id="session-1",
-        timestamp=older_ts,
-        usage={"input_tokens": 10, "cached_input_tokens": 0, "output_tokens": 5},
+        sessions_dir / "newer-dir" / "newer.jsonl",
+        session_id="same-session",
+        timestamp=newer_ts,
+        usage={"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 30},
     )
     _write_session(
-        sessions_dir / "newer.jsonl",
-        session_id="session-1",
-        timestamp=newer_ts,
-        usage={"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 50},
+        sessions_dir / "older-dir" / "older.jsonl",
+        session_id="same-session",
+        timestamp=older_ts,
+        usage={"input_tokens": 10, "cached_input_tokens": 2, "output_tokens": 3},
     )
 
     entries = codex_loader.load_entries()
 
     assert len(entries) == 1
     assert entries[0].timestamp == datetime.fromisoformat(newer_ts)
-    assert entries[0].total_tokens == 150
+    assert entries[0].total_tokens == 130
 
 
-def test_load_entries_uses_larger_duplicate_when_timestamps_match(
+def test_load_entries_keeps_larger_duplicate_when_timestamps_match(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     sessions_dir = tmp_path / "sessions"
@@ -118,21 +143,63 @@ def test_load_entries_uses_larger_duplicate_when_timestamps_match(
     timestamp = datetime.now(UTC).isoformat()
     _write_session(
         sessions_dir / "small.jsonl",
-        session_id="session-1",
+        session_id="same-session",
         timestamp=timestamp,
-        usage={"input_tokens": 10, "cached_input_tokens": 0, "output_tokens": 5},
+        usage={"input_tokens": 10, "cached_input_tokens": 2, "output_tokens": 3},
     )
     _write_session(
         sessions_dir / "large.jsonl",
-        session_id="session-1",
+        session_id="same-session",
         timestamp=timestamp,
-        usage={"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 50},
+        usage={"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 30},
     )
 
     entries = codex_loader.load_entries()
 
     assert len(entries) == 1
-    assert entries[0].total_tokens == 150
+    assert entries[0].total_tokens == 130
+
+
+def test_load_entries_splits_cumulative_usage_into_time_range_deltas(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    old_ts = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+    recent_ts = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    _write_session_with_usage_events(
+        sessions_dir / "long-running.jsonl",
+        session_id="long-running",
+        events=[
+            (
+                old_ts,
+                {
+                    "input_tokens": 110,
+                    "cached_input_tokens": 10,
+                    "output_tokens": 50,
+                },
+            ),
+            (
+                recent_ts,
+                {
+                    "input_tokens": 160,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 70,
+                    "reasoning_output_tokens": 10,
+                },
+            ),
+        ],
+    )
+
+    all_entries = codex_loader.load_entries()
+    week_entries = codex_loader.load_entries(hours_back=168)
+
+    assert [entry.total_tokens for entry in all_entries] == [160, 80]
+    assert [entry.total_tokens for entry in week_entries] == [80]
+    assert week_entries[0].input_tokens == 40
+    assert week_entries[0].output_tokens == 30
+    assert week_entries[0].cache_read_tokens == 10
 
 
 def test_parse_jsonl_skips_bad_lines_and_missing_fields(tmp_path: Path) -> None:
@@ -148,7 +215,7 @@ def test_parse_jsonl_skips_bad_lines_and_missing_fields(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    assert codex_loader._parse_jsonl(path, {}, None) is None
+    assert codex_loader._parse_jsonl(path, {}, None) == []
 
 
 def test_parse_timestamp_accepts_expected_iso8601_variants() -> None:


### PR DESCRIPTION
## Summary
- split Codex cumulative token_count snapshots into per-event deltas before aggregation
- keep duplicate-session handling by choosing the better complete session log, then flattening its delta entries
- fixes period buckets like Today / 7d / 30d so older cumulative usage does not leak into newer ranges

## Test plan
- [x] .venv/bin/python -m ruff check codex_loader.py tests/test_codex_loader.py
- [x] .venv/bin/python -m mypy .
- [x] .venv/bin/python -m pytest tests/test_codex_loader.py tests/test_analyzer_pipeline.py tests/test_menubar.py

## Notes for reviewer
This keeps the rate-limit parser unchanged. It only changes the historical usage entries emitted from Codex session logs so downstream aggregators can bucket usage by each token_count event timestamp.