### PR TITLE
fix: queue manual refresh while busy

### DIFF
--- a/menubar.py
+++ b/menubar.py
@@ -325,6 +325,7 @@ class AppDelegate(NSObject):
     codex_model = objc.ivar()
     burn_rate_trackers = objc.ivar()
     _refresh_in_flight = objc.ivar()
+    _refresh_queued = objc.ivar()
     _fs_stream = objc.ivar()
     _history_entries_cache = objc.ivar()
     _history_entries_cache_fingerprint = objc.ivar()
@@ -349,6 +350,7 @@ class AppDelegate(NSObject):
             "codex_weekly": BurnRateTracker(),
         }
         self._refresh_in_flight = False
+        self._refresh_queued = False
         self._fs_stream = None
         self._history_entries_cache = None
         self._history_entries_cache_fingerprint = None
@@ -390,7 +392,7 @@ class AppDelegate(NSObject):
         self._refresh()
 
     def refreshNow_(self, sender: Any) -> None:
-        self._refresh()
+        self._refresh(queue_if_busy=True)
 
     def installHook_(self, sender: Any) -> None:
         thread = threading.Thread(target=self._install_hook_in_background, daemon=True)
@@ -621,8 +623,10 @@ class AppDelegate(NSObject):
         button = self.status_item.button()
         self.popover.showRelativeToRect_ofView_preferredEdge_(button.bounds(), button, NSMinYEdge)
 
-    def _refresh(self) -> None:
+    def _refresh(self, queue_if_busy: bool = False) -> None:
         if self._refresh_in_flight:
+            if queue_if_busy:
+                self._refresh_queued = True
             return
         self._refresh_in_flight = True
         thread = threading.Thread(target=self._refresh_in_background, daemon=True)
@@ -660,18 +664,25 @@ class AppDelegate(NSObject):
         )
 
     def _applyRefreshResult_(self, result: dict[str, Any]) -> None:
-        state = result["state"]
-        codex_5h_pct = result["codex_5h_pct"]
-        codex_model = result.get("codex_model", "unknown")
-        self.codex_5h_pct = codex_5h_pct
-        self.codex_model = codex_model
-        self.latest_state = state
-        if self.popover.isShown():
-            self.popover_controller.setState_(self.latest_state)
-        self.popover.setContentSize_(_popover_size(state, self.active_panel))
-        self._inject_web_language(state.language)
-        self.status_item.button().setTitle_(self._compose_title(state))
-        self._refresh_in_flight = False
+        should_refresh_again = False
+        try:
+            state = result["state"]
+            codex_5h_pct = result["codex_5h_pct"]
+            codex_model = result.get("codex_model", "unknown")
+            self.codex_5h_pct = codex_5h_pct
+            self.codex_model = codex_model
+            self.latest_state = state
+            if self.popover.isShown():
+                self.popover_controller.setState_(self.latest_state)
+            self.popover.setContentSize_(_popover_size(state, self.active_panel))
+            self._inject_web_language(state.language)
+            self.status_item.button().setTitle_(self._compose_title(state))
+        finally:
+            should_refresh_again = bool(self._refresh_queued)
+            self._refresh_queued = False
+            self._refresh_in_flight = False
+        if should_refresh_again:
+            self._refresh()
 
     def _inject_web_language(self, language: str) -> None:
         content_view = self.popover_controller.content_view

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -967,23 +967,57 @@ def test_apply_refresh_result_pushes_state_only_when_popover_is_shown() -> None:
     delegate.popover = FakePopover(shown=True)
     delegate.status_item = FakeStatusItem(button)
     delegate._refresh_in_flight = True
+    delegate._refresh_queued = False
 
     delegate._applyRefreshResult_({"state": state, "codex_5h_pct": 12})
 
     assert controller.calls == [state]
     assert delegate.latest_state == state
     assert delegate.codex_5h_pct == 12
+    assert delegate._refresh_in_flight is False
     assert button.titles
 
     controller.calls.clear()
     delegate.popover = FakePopover(shown=False)
     delegate._refresh_in_flight = True
+    delegate._refresh_queued = False
 
     delegate._applyRefreshResult_({"state": state, "codex_5h_pct": 34})
 
     assert controller.calls == []
     assert delegate.latest_state == state
     assert delegate.codex_5h_pct == 34
+    assert delegate._refresh_in_flight is False
+
+
+def test_refresh_now_queues_when_refresh_is_busy() -> None:
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(True, 60)
+    delegate._refresh_in_flight = True
+    delegate._refresh_queued = False
+
+    delegate.refreshNow_(None)
+
+    assert delegate._refresh_queued is True
+
+
+def test_apply_refresh_result_clears_busy_flag_when_ui_update_fails() -> None:
+    class FailingPopover:
+        def isShown(self) -> bool:
+            return False
+
+        def setContentSize_(self, size: object) -> None:
+            raise RuntimeError("size failed")
+
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(True, 60)
+    delegate.popover = FailingPopover()
+    delegate._refresh_in_flight = True
+    delegate._refresh_queued = False
+
+    with pytest.raises(RuntimeError, match="size failed"):
+        delegate._applyRefreshResult_({"state": menubar._empty_state(), "codex_5h_pct": None})
+
+    assert delegate._refresh_in_flight is False
+    assert delegate._refresh_queued is False
 
 
 def test_switching_visible_panel_reopens_popover(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- queue one manual refresh when the user clicks Refresh while a background refresh is already running
- clear the in-flight flag in a finally block so UI update failures do not permanently block future refreshes
- run the queued refresh immediately after the current refresh result is applied

## Test plan
- [x] .venv/bin/python -m ruff check menubar.py tests/test_menubar.py
- [x] .venv/bin/python -m mypy .
- [x] .venv/bin/python -m pytest tests/test_menubar.py

## Notes for reviewer
This only changes explicit manual refresh behavior. Timer and FSEvents refresh calls still coalesce while a refresh is in flight.