### PR TITLE
fix: store pricing cache under usage state

### DIFF
--- a/pricing.py
+++ b/pricing.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 LITELLM_PRICING_URL = (
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
 )
-CACHE_PATH = Path(os.path.expanduser("~/.claude/pricing_cache.json"))
+DEFAULT_CACHE_PATH = Path(os.path.expanduser("~/.usage/pricing_cache.json"))
+DEFAULT_LEGACY_CACHE_PATH = Path(os.path.expanduser("~/.claude/pricing_cache.json"))
+CACHE_PATH = DEFAULT_CACHE_PATH
+LEGACY_CACHE_PATH = DEFAULT_LEGACY_CACHE_PATH
 CACHE_TTL_DAYS = 7
 FALLBACK_RETRY_SECONDS = 600
 USER_AGENT = "usage/0.9"
@@ -106,20 +109,22 @@ def _load_pricing_with_source() -> tuple[PricingTable, PricingSource]:
 
 
 def _read_cache() -> PricingTable | None:
+    use_legacy = CACHE_PATH == DEFAULT_CACHE_PATH or LEGACY_CACHE_PATH != DEFAULT_LEGACY_CACHE_PATH
+    path = CACHE_PATH if CACHE_PATH.exists() or not use_legacy else LEGACY_CACHE_PATH
     cache_mtime: float | None = None
     with contextlib.suppress(OSError):
-        cache_mtime = CACHE_PATH.stat().st_mtime
+        cache_mtime = path.stat().st_mtime
     if cache_mtime is None:
         return None
     if (time.time() - cache_mtime) > CACHE_TTL_DAYS * 86400:
         return None
 
-    with contextlib.suppress(OSError), CACHE_PATH.open(encoding="utf-8") as file:
+    with contextlib.suppress(OSError), path.open(encoding="utf-8") as file:
         try:
             return _normalize_pricing(json.load(file))
         except json.JSONDecodeError:
             if os.environ.get("USAGE_DEBUG") == "1":
-                logger.warning("failed to decode pricing cache %s", CACHE_PATH, exc_info=True)
+                logger.warning("failed to decode pricing cache %s", path, exc_info=True)
             return None
     return None
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -244,6 +244,21 @@ def test_read_cache_valid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     assert pricing._read_cache() == {"model": {"input_cost_per_token": 1.0}}
 
 
+def test_read_cache_uses_legacy_claude_path_when_new_cache_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    legacy_cache = tmp_path / ".claude" / "pricing_cache.json"
+    legacy_cache.parent.mkdir()
+    legacy_cache.write_text(
+        json.dumps({"legacy-model": {"input_cost_per_token": 1.0}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pricing, "CACHE_PATH", tmp_path / ".usage" / "pricing_cache.json")
+    monkeypatch.setattr(pricing, "LEGACY_CACHE_PATH", legacy_cache)
+
+    assert pricing._read_cache() == {"legacy-model": {"input_cost_per_token": 1.0}}
+
+
 def test_load_pricing_falls_back_when_fetch_fails_without_real_network(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- move the default LiteLLM pricing cache from ~/.claude/pricing_cache.json to ~/.usage/pricing_cache.json
- keep reading the legacy Claude path when the new usage-owned cache is missing
- continue writing fetched pricing only to the new usage-owned cache path

## Test plan
- [x] .venv/bin/python -m ruff check pricing.py tests/test_pricing.py
- [x] .venv/bin/python -m mypy .
- [x] .venv/bin/python -m pytest tests/test_pricing.py

## Notes for reviewer
This does not change cost calculation or model matching. It only moves usage-owned cache state out of ~/.claude while preserving legacy read compatibility.