### PR TITLE
fix: make report CLI help explicit

### DIFF
--- a/tests/test_usage_cli.py
+++ b/tests/test_usage_cli.py
@@ -88,6 +88,80 @@ def test_main_daily_sort_flag_controls_render_order(monkeypatch: pytest.MonkeyPa
     assert [stat.total_tokens for stat in rendered["stats"]] == [11, 110]
 
 
+@pytest.mark.parametrize(
+    ("argv", "expected_period"),
+    [
+        (["usage", "report"], "last30"),
+        (["usage", "report", "--last30"], "last30"),
+        (["usage", "report", "--all"], "all"),
+    ],
+)
+def test_main_report_parses_period(
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+    expected_period: str,
+) -> None:
+    from analyzer import reporter
+    from ui import html_report
+
+    agent = AgentInfo("codex", "Codex", "~/.codex", True)
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(usage_cli, "detect_agents", lambda: [agent])
+    monkeypatch.setattr(usage_cli, "is_setup", lambda: True)
+    monkeypatch.setattr(
+        reporter,
+        "build_report_data",
+        lambda agents, period: calls.update(agents=agents, period=period) or {},
+    )
+    monkeypatch.setattr(html_report, "save_and_open", lambda data, out_path=None: "report.html")
+
+    usage_cli.main()
+
+    assert calls == {"agents": [agent], "period": expected_period}
+
+
+def test_main_report_help_does_not_build_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    from analyzer import reporter
+
+    printed: list[str] = []
+
+    monkeypatch.setattr(sys, "argv", ["usage", "report", "--help"])
+    monkeypatch.setattr(
+        usage_cli,
+        "detect_agents",
+        lambda: pytest.fail("report help should not detect agents"),
+    )
+    monkeypatch.setattr(usage_cli, "is_setup", lambda: True)
+    monkeypatch.setattr(usage_cli.console, "print", lambda value: printed.append(str(value)))
+    monkeypatch.setattr(
+        reporter,
+        "build_report_data",
+        lambda agents, period: pytest.fail("report help should not build a report"),
+    )
+
+    usage_cli.main()
+
+    assert any("Usage: usage report" in line for line in printed)
+
+
+def test_main_report_rejects_unknown_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    agent = AgentInfo("codex", "Codex", "~/.codex", True)
+    printed: list[str] = []
+
+    monkeypatch.setattr(sys, "argv", ["usage", "report", "--bogus"])
+    monkeypatch.setattr(usage_cli, "detect_agents", lambda: [agent])
+    monkeypatch.setattr(usage_cli, "is_setup", lambda: True)
+    monkeypatch.setattr(usage_cli.console, "print", lambda value: printed.append(str(value)))
+
+    with pytest.raises(SystemExit) as exc_info:
+        usage_cli.main()
+
+    assert exc_info.value.code == 1
+    assert any("unknown report option" in line for line in printed)
+
+
 def test_main_exits_when_no_agents_detected(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["usage", "dashboard"])
     monkeypatch.setattr(usage_cli, "detect_agents", lambda: [])

--- a/usage_cli.py
+++ b/usage_cli.py
@@ -26,6 +26,20 @@ SORT_KEYS = {
     "output": ("output_tokens", True),
 }
 
+REPORT_HELP = """Usage: usage report [--last30|--all|--today|--week|--month] [--out PATH]
+
+Generate an HTML usage report.
+
+Options:
+  --last30    Include the last 30 days (default)
+  --all       Include all usage data
+  --today     Include today only
+  --week      Include this week
+  --month     Include this month
+  --out PATH  Save to a specific path
+  -h, --help  Show this help
+"""
+
 
 def _parse_sort_args(args: list[str]) -> tuple[list[str], str | None, bool]:
     """Extract --sort KEY and --asc from args, return (remaining, sort_key, descending)."""
@@ -47,6 +61,43 @@ def _parse_sort_args(args: list[str]) -> tuple[list[str], str | None, bool]:
             remaining.append(args[i])
             i += 1
     return remaining, sort_key, descending
+
+
+def _parse_report_args(args: list[str]) -> tuple[str, str | None, bool]:
+    period = "last30"
+    out_path = None
+    show_help = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in {"-h", "--help"}:
+            show_help = True
+        elif arg == "--last30":
+            period = "last30"
+        elif arg == "--today":
+            period = "today"
+        elif arg == "--week":
+            period = "week"
+        elif arg == "--month":
+            period = "month"
+        elif arg == "--all":
+            period = "all"
+        elif arg.startswith("--out="):
+            out_path = arg[6:]
+        elif arg == "--out":
+            if i + 1 >= len(args) or args[i + 1].startswith("--"):
+                console.print("[red]Error:[/red] --out requires a path")
+                sys.exit(1)
+            out_path = args[i + 1]
+            i += 1
+        elif arg.startswith("-"):
+            console.print(f"[red]Error:[/red] unknown report option: {arg}")
+            sys.exit(1)
+        else:
+            console.print(f"[red]Error:[/red] unexpected report argument: {arg}")
+            sys.exit(1)
+        i += 1
+    return period, out_path, show_help
 
 
 def _apply_sort(stats, sort_key: str | None, descending: bool, default_attr: str, default_reverse: bool):
@@ -364,6 +415,9 @@ def main():
     if command in ("--version", "-v", "-V"):
         print(f"usage {_get_version()}")
         return
+    if command == "report" and any(arg in {"-h", "--help"} for arg in args[1:]):
+        console.print(REPORT_HELP)
+        return
     if command == "setup":
         setup()
         return
@@ -412,25 +466,10 @@ def main():
     rest_args, sort_key, sort_desc = _parse_sort_args(args[1:])
 
     if command == "report":
-        period = "last30"
-        out_path = None
-        i = 1
-        while i < len(args):
-            arg = args[i]
-            if arg == "--today":
-                period = "today"
-            elif arg == "--week":
-                period = "week"
-            elif arg == "--month":
-                period = "month"
-            elif arg == "--all":
-                period = "all"
-            elif arg.startswith("--out="):
-                out_path = arg[6:]
-            elif arg == "--out" and i + 1 < len(args):
-                out_path = args[i + 1]
-                i += 1
-            i += 1
+        period, out_path, show_help = _parse_report_args(args[1:])
+        if show_help:
+            console.print(REPORT_HELP)
+            return
         from analyzer.reporter import build_report_data
         from ui.html_report import save_and_open
 


### PR DESCRIPTION
## Summary
- add explicit parsing for usage report options, including --last30 and --help
- make usage report --help return before agent detection or report generation
- reject unknown report options and --out without a path instead of silently ignoring them

## Test plan
- [x] .venv/bin/python -m ruff check usage_cli.py tests/test_usage_cli.py
- [x] .venv/bin/python -m mypy .
- [x] .venv/bin/python -m pytest tests/test_usage_cli.py
- [x] .venv/bin/python usage_cli.py report --help

## Notes for reviewer
This keeps the existing upstream default report range as last30. It only makes the CLI behavior explicit and easier to validate.