### PR TITLE
perf: cache project usage history between refreshes

### DIFF
--- a/menubar.py
+++ b/menubar.py
@@ -323,6 +323,8 @@ class AppDelegate(NSObject):
     burn_rate_trackers = objc.ivar()
     _refresh_in_flight = objc.ivar()
     _fs_stream = objc.ivar()
+    _history_entries_cache = objc.ivar()
+    _history_entries_cache_fingerprint = objc.ivar()
     language = objc.ivar()
 
     def initWithMock_interval_(self, mock: bool, interval: int) -> AppDelegate:
@@ -344,6 +346,8 @@ class AppDelegate(NSObject):
         }
         self._refresh_in_flight = False
         self._fs_stream = None
+        self._history_entries_cache = None
+        self._history_entries_cache_fingerprint = None
         return self
 
     def applicationDidFinishLaunching_(self, notification: Any) -> None:
@@ -934,9 +938,39 @@ class AppDelegate(NSObject):
         )
         return rows, codex_5h_pct
 
+    def _history_sources_fingerprint(self) -> tuple[tuple[str, int, float], ...]:
+        sources = (
+            Path.home() / ".claude",
+            Path.home() / ".codex" / "sessions",
+        )
+        fingerprint: list[tuple[str, int, float]] = []
+        for source in sources:
+            newest_mtime = 0.0
+            file_count = 0
+            try:
+                if source.exists():
+                    for path in source.rglob("*.jsonl"):
+                        try:
+                            stat = path.stat()
+                        except OSError:
+                            continue
+                        file_count += 1
+                        newest_mtime = max(newest_mtime, stat.st_mtime)
+            except OSError:
+                pass
+            fingerprint.append((str(source), file_count, newest_mtime))
+        return tuple(fingerprint)
+
     def _load_history_entries(self) -> list[UsageEntry]:
         if self.mock:
             return []
+        fingerprint = self._history_sources_fingerprint()
+        if (
+            self._history_entries_cache is not None
+            and self._history_entries_cache_fingerprint == fingerprint
+        ):
+            return list(self._history_entries_cache)
+
         entries: list[UsageEntry] = []
         try:
             entries.extend(load_entries(hours_back=720))
@@ -948,6 +982,8 @@ class AppDelegate(NSObject):
         except Exception:
             if os.environ.get("USAGE_DEBUG") == "1":
                 logger.warning("Codex project usage load failed", exc_info=True)
+        self._history_entries_cache = list(entries)
+        self._history_entries_cache_fingerprint = fingerprint
         return entries
 
     def _project_rows(

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import pytest
 
+import codex_loader
 import history_loader
 import menubar
 from usage_client import PollOutcome, PollState, UsageSnapshot
@@ -592,6 +593,97 @@ def test_load_history_entries_includes_codex_entries(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr("menubar.codex_loader.load_entries", lambda *, hours_back: [codex_entry])
 
     assert delegate._load_history_entries() == [claude_entry, codex_entry]
+
+
+def test_load_history_entries_reuses_cache_when_sources_do_not_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(False, 60)
+    claude_entry = history_loader.UsageEntry(
+        timestamp=datetime(2026, 5, 21, tzinfo=UTC),
+        session_id="claude-session",
+        message_id="claude-message",
+        request_id="claude-request",
+        model="claude",
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_tokens=0,
+        cache_read_tokens=0,
+        cost_usd=0.01,
+        project="ClaudeProject",
+    )
+    codex_entry = history_loader.UsageEntry(
+        timestamp=datetime(2026, 5, 22, tzinfo=UTC),
+        session_id="codex-session",
+        message_id="codex-message",
+        request_id="",
+        model="gpt",
+        input_tokens=20,
+        output_tokens=7,
+        cache_creation_tokens=0,
+        cache_read_tokens=0,
+        cost_usd=None,
+        project="CodexProject",
+    )
+    calls = {"claude": 0, "codex": 0}
+
+    def fake_claude_entries(*, hours_back: int = 720) -> list[history_loader.UsageEntry]:
+        calls["claude"] += 1
+        assert hours_back == 720
+        return [claude_entry]
+
+    def fake_codex_entries(*, hours_back: int = 720) -> list[history_loader.UsageEntry]:
+        calls["codex"] += 1
+        assert hours_back == 720
+        return [codex_entry]
+
+    monkeypatch.setattr(delegate, "_history_sources_fingerprint", lambda: (("same", 1, 1.0),))
+    monkeypatch.setattr(menubar, "load_entries", fake_claude_entries)
+    monkeypatch.setattr(codex_loader, "load_entries", fake_codex_entries)
+
+    first = delegate._load_history_entries()
+    second = delegate._load_history_entries()
+
+    assert first == [claude_entry, codex_entry]
+    assert second == first
+    assert calls == {"claude": 1, "codex": 1}
+
+
+def test_load_history_entries_refreshes_cache_when_sources_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(False, 60)
+    entries = [
+        history_loader.UsageEntry(
+            timestamp=datetime(2026, 5, 22, tzinfo=UTC),
+            session_id="codex-session",
+            message_id="codex-message",
+            request_id="",
+            model="gpt",
+            input_tokens=20,
+            output_tokens=7,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=None,
+            project="CodexProject",
+        )
+    ]
+    calls = 0
+    fingerprints = iter(((("old", 1, 1.0),), (("new", 2, 2.0),)))
+
+    def fake_codex_entries(*, hours_back: int = 720) -> list[history_loader.UsageEntry]:
+        nonlocal calls
+        calls += 1
+        assert hours_back == 720
+        return entries
+
+    monkeypatch.setattr(delegate, "_history_sources_fingerprint", lambda: next(fingerprints))
+    monkeypatch.setattr(menubar, "load_entries", lambda *, hours_back=720: [])
+    monkeypatch.setattr(codex_loader, "load_entries", fake_codex_entries)
+
+    assert delegate._load_history_entries() == entries
+    assert delegate._load_history_entries() == entries
+    assert calls == 2
 
 
 def test_project_rows_top3(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- cache combined Claude/Codex project history entries between menu bar refreshes
- invalidate the cache when the watched history source fingerprint changes
- avoid reparsing the same 30-day history repeatedly when switching Project Usage ranges or refreshing without new log files

## Test plan
- [x] .venv/bin/python -m ruff check menubar.py tests/test_menubar.py
- [x] .venv/bin/python -m mypy .
- [x] .venv/bin/python -m pytest tests/test_menubar.py

## Notes for reviewer
This preserves the current upstream 30-day history load window. It only skips repeat parsing while the source files are unchanged.