### PR TITLE
fix: read current Codex Desktop logs

### DIFF
--- a/codex_loader.py
+++ b/codex_loader.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import re
 import sqlite3
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ _jsonl_cache: OrderedDict[Path, tuple[float, int, list[UsageEntry]]] = OrderedDi
 
 SESSIONS_DIR = Path(os.path.expanduser("~/.codex/sessions"))
 STATE_DB = Path(os.path.expanduser("~/.codex/state_5.sqlite"))
+LOGS_DB = Path(os.path.expanduser("~/.codex/logs_2.sqlite"))
 
 
 @dataclass(slots=True)
@@ -34,35 +36,47 @@ class CodexRateLimits:
     updated_at: str = ""
 
 
-def load_entries(hours_back: int = 0) -> list[UsageEntry]:
-    if not SESSIONS_DIR.is_dir():
-        return []
+@dataclass(frozen=True, slots=True)
+class _ThreadMetadata:
+    model: str = "unknown"
+    cwd: str = ""
 
+
+def load_entries(hours_back: int = 0) -> list[UsageEntry]:
     entries_by_session: dict[str, list[UsageEntry]] = {}
     cutoff = datetime.now(UTC) - timedelta(hours=hours_back) if hours_back > 0 else None
     cutoff_ts = cutoff.timestamp() if cutoff else None
-    models = _load_thread_models()
+    metadata = _load_thread_metadata()
+    models = {session_id: data.model for session_id, data in metadata.items()}
 
-    for jsonl_path in SESSIONS_DIR.rglob("*.jsonl"):
-        if cutoff_ts is not None:
-            try:
-                if jsonl_path.stat().st_mtime < cutoff_ts:
+    if SESSIONS_DIR.is_dir():
+        for jsonl_path in SESSIONS_DIR.rglob("*.jsonl"):
+            if cutoff_ts is not None:
+                try:
+                    if jsonl_path.stat().st_mtime < cutoff_ts:
+                        continue
+                except OSError as exc:
+                    logger.warning("failed to stat session log %s: %s", jsonl_path, exc)
                     continue
-            except OSError as exc:
-                logger.warning("failed to stat session log %s: %s", jsonl_path, exc)
+            parsed = _parse_jsonl(jsonl_path, models, cutoff)
+            if not parsed:
                 continue
-        parsed = _parse_jsonl(jsonl_path, models, cutoff)
-        if not parsed:
-            continue
-        existing = entries_by_session.get(parsed[0].session_id)
-        if existing is None or _is_better_session_log(parsed, existing):
-            entries_by_session[parsed[0].session_id] = parsed
+            existing = entries_by_session.get(parsed[0].session_id)
+            if existing is None or _is_better_session_log(parsed, existing):
+                entries_by_session[parsed[0].session_id] = parsed
+
+    latest_jsonl_ts_by_session = {
+        session_id: session_entries[-1].timestamp
+        for session_id, session_entries in entries_by_session.items()
+        if session_entries
+    }
 
     entries = [
         entry
         for session_entries in entries_by_session.values()
         for entry in session_entries
     ]
+    entries.extend(_load_sqlite_log_entries(metadata, cutoff, latest_jsonl_ts_by_session))
     entries.sort(key=lambda entry: entry.timestamp)
     return entries
 
@@ -92,22 +106,143 @@ def load_rate_limits() -> CodexRateLimits | None:
 
 
 def _load_thread_models() -> dict[str, str]:
+    return {
+        thread_id: metadata.model
+        for thread_id, metadata in _load_thread_metadata().items()
+    }
+
+
+def _load_thread_metadata() -> dict[str, _ThreadMetadata]:
     if not STATE_DB.exists():
         return {}
     try:
         with sqlite3.connect(f"file:{STATE_DB}?mode=ro", uri=True) as conn:
             rows = conn.execute(
-                "SELECT id, model FROM threads WHERE model IS NOT NULL",
+                "SELECT id, model, cwd FROM threads",
             ).fetchall()
     except (OSError, sqlite3.Error):
         if os.environ.get("USAGE_DEBUG") == "1":
-            logger.warning("codex thread models load failed", exc_info=True)
+            logger.warning("codex thread metadata load failed", exc_info=True)
         return {}
     return {
-        thread_id: model
-        for thread_id, model in rows
-        if isinstance(thread_id, str) and isinstance(model, str) and model
+        thread_id: _ThreadMetadata(
+            model=model if isinstance(model, str) and model else "unknown",
+            cwd=cwd if isinstance(cwd, str) else "",
+        )
+        for thread_id, model, cwd in rows
+        if isinstance(thread_id, str) and thread_id
     }
+
+
+def _load_sqlite_log_entries(
+    metadata: dict[str, _ThreadMetadata],
+    cutoff: datetime | None,
+    latest_jsonl_ts_by_session: dict[str, datetime],
+) -> list[UsageEntry]:
+    if not LOGS_DB.exists():
+        return []
+    cutoff_ts = cutoff.timestamp() if cutoff else None
+    query = (
+        "SELECT id, ts, ts_nanos, feedback_log_body FROM logs "
+        "WHERE target = 'codex_otel.trace_safe' "
+        "AND feedback_log_body LIKE '%event.kind=response.completed%' "
+        "AND feedback_log_body LIKE '%input_token_count=%'"
+    )
+    params: tuple[float, ...] = ()
+    if cutoff_ts is not None:
+        query += " AND ts >= ?"
+        params = (cutoff_ts,)
+    query += " ORDER BY ts ASC, ts_nanos ASC, id ASC"
+    try:
+        with sqlite3.connect(f"file:{LOGS_DB}?mode=ro", uri=True) as conn:
+            rows = conn.execute(query, params).fetchall()
+    except (OSError, sqlite3.Error):
+        if os.environ.get("USAGE_DEBUG") == "1":
+            logger.warning("codex sqlite logs load failed", exc_info=True)
+        return []
+
+    entries: list[UsageEntry] = []
+    for row_id, ts, ts_nanos, body in rows:
+        entry = _parse_sqlite_log_row(row_id, ts, ts_nanos, body, metadata)
+        if entry is None:
+            continue
+        if cutoff is not None and entry.timestamp < cutoff:
+            continue
+        latest_jsonl_ts = latest_jsonl_ts_by_session.get(entry.session_id)
+        if latest_jsonl_ts is not None and entry.timestamp <= latest_jsonl_ts:
+            continue
+        entries.append(entry)
+    return entries
+
+
+def _parse_sqlite_log_row(
+    row_id: Any,
+    ts: Any,
+    ts_nanos: Any,
+    body: Any,
+    metadata: dict[str, _ThreadMetadata],
+) -> UsageEntry | None:
+    if not isinstance(body, str):
+        return None
+    if 'event.name="codex.sse_event"' not in body or "event.kind=response.completed" not in body:
+        return None
+    session_id = _event_value(body, "conversation.id")
+    if not session_id:
+        return None
+    timestamp = _parse_timestamp(_event_value(body, "event.timestamp"))
+    if timestamp is None:
+        timestamp = _timestamp_from_log_ts(ts)
+    if timestamp is None:
+        return None
+    cached = _as_int(_event_value(body, "cached_token_count"))
+    input_tokens = max(0, _as_int(_event_value(body, "input_token_count")) - cached)
+    output_tokens = _as_int(_event_value(body, "output_token_count")) + _as_int(
+        _event_value(body, "reasoning_token_count")
+    )
+    if input_tokens + output_tokens + cached == 0:
+        return None
+    thread = metadata.get(session_id, _ThreadMetadata())
+    model = _event_value(body, "model") or thread.model
+    project = _project_from_cwd(thread.cwd) if thread.cwd else "unknown"
+    return UsageEntry(
+        timestamp=timestamp,
+        session_id=session_id,
+        message_id=f"{session_id}:sqlite:{row_id}:{ts_nanos}",
+        request_id="",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_tokens=0,
+        cache_read_tokens=cached,
+        cost_usd=None,
+        project=project,
+    )
+
+
+_EVENT_VALUE_RE_CACHE: dict[str, re.Pattern[str]] = {}
+
+
+def _event_value(body: str, key: str) -> str:
+    pattern = _EVENT_VALUE_RE_CACHE.get(key)
+    if pattern is None:
+        pattern = re.compile(rf'(?:^|\s){re.escape(key)}=(?:"([^"]*)"|([^\s]+))')
+        _EVENT_VALUE_RE_CACHE[key] = pattern
+    match = pattern.search(body)
+    if match is None:
+        return ""
+    return match.group(1) if match.group(1) is not None else match.group(2)
+
+
+def _timestamp_from_log_ts(value: Any) -> datetime | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(timestamp):
+        return None
+    return datetime.fromtimestamp(timestamp, UTC)
 
 
 def _recent_jsonl_files() -> list[Path]:

--- a/codex_loader.py
+++ b/codex_loader.py
@@ -94,6 +94,9 @@ def _session_total_tokens(entries: list[UsageEntry]) -> int:
 
 
 def load_rate_limits() -> CodexRateLimits | None:
+    sqlite_limits = _load_sqlite_rate_limits()
+    if sqlite_limits is not None:
+        return sqlite_limits
     if not SESSIONS_DIR.is_dir():
         return None
     models = _load_thread_models()
@@ -103,6 +106,132 @@ def load_rate_limits() -> CodexRateLimits | None:
         if rate_limits is not None:
             return rate_limits
     return None
+
+
+def _load_sqlite_rate_limits() -> CodexRateLimits | None:
+    if not LOGS_DB.exists():
+        return None
+    query = (
+        "SELECT ts, feedback_log_body FROM logs "
+        "WHERE target = 'codex_api::endpoint::responses_websocket' "
+        "AND feedback_log_body LIKE '%websocket event:%' "
+        "AND (feedback_log_body LIKE '%\"type\":\"codex.rate_limits\"%' "
+        "OR feedback_log_body LIKE '%\"type\":\"error\"%usage_limit_reached%') "
+        "ORDER BY ts DESC, ts_nanos DESC, id DESC LIMIT 50"
+    )
+    try:
+        with sqlite3.connect(f"file:{LOGS_DB}?mode=ro", uri=True) as conn:
+            rows = conn.execute(query).fetchall()
+    except (OSError, sqlite3.Error):
+        if os.environ.get("USAGE_DEBUG") == "1":
+            logger.warning("codex sqlite rate limits load failed", exc_info=True)
+        return None
+
+    for ts, body in rows:
+        parsed = _parse_sqlite_rate_limits_row(ts, body)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _parse_sqlite_rate_limits_row(ts: Any, body: Any) -> CodexRateLimits | None:
+    if not isinstance(body, str):
+        return None
+    event = _websocket_event_payload(body)
+    if not event:
+        return None
+    if event.get("type") == "codex.rate_limits":
+        return _rate_limits_from_websocket_event(event, body, ts)
+    if event.get("type") == "error":
+        return _rate_limits_from_websocket_error(event, body, ts)
+    return None
+
+
+def _websocket_event_payload(body: str) -> dict[str, Any]:
+    marker = "websocket event: "
+    index = body.find(marker)
+    if index < 0:
+        return {}
+    try:
+        data = json.loads(body[index + len(marker):])
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _rate_limits_from_websocket_event(
+    event: dict[str, Any],
+    body: str,
+    ts: Any,
+) -> CodexRateLimits | None:
+    rate_limits = _as_dict(event.get("rate_limits"))
+    primary = _as_dict(rate_limits.get("primary"))
+    secondary = _as_dict(rate_limits.get("secondary"))
+    return _build_rate_limits(
+        primary_pct=_as_optional_float(primary.get("used_percent")),
+        primary_reset=_as_optional_float(primary.get("reset_at")),
+        secondary_pct=_as_optional_float(secondary.get("used_percent")),
+        secondary_reset=_as_optional_float(secondary.get("reset_at")),
+        model=_event_value(body, "model") or "unknown",
+        updated_at=_timestamp_from_log_ts(ts),
+    )
+
+
+def _rate_limits_from_websocket_error(
+    event: dict[str, Any],
+    body: str,
+    ts: Any,
+) -> CodexRateLimits | None:
+    headers = _as_dict(event.get("headers"))
+    primary_reset = _as_optional_float(headers.get("X-Codex-Primary-Reset-At"))
+    secondary_reset = _as_optional_float(headers.get("X-Codex-Secondary-Reset-At"))
+    now_ts = datetime.now(UTC).timestamp()
+    if primary_reset is None:
+        primary_reset_after = _as_optional_float(headers.get("X-Codex-Primary-Reset-After-Seconds"))
+        primary_reset = now_ts + primary_reset_after if primary_reset_after is not None else None
+    if secondary_reset is None:
+        secondary_reset_after = _as_optional_float(
+            headers.get("X-Codex-Secondary-Reset-After-Seconds")
+        )
+        secondary_reset = (
+            now_ts + secondary_reset_after if secondary_reset_after is not None else None
+        )
+    return _build_rate_limits(
+        primary_pct=_as_optional_float(headers.get("X-Codex-Primary-Used-Percent")),
+        primary_reset=primary_reset,
+        secondary_pct=_as_optional_float(headers.get("X-Codex-Secondary-Used-Percent")),
+        secondary_reset=secondary_reset,
+        model=_event_value(body, "model") or "unknown",
+        updated_at=_timestamp_from_log_ts(ts),
+    )
+
+
+def _build_rate_limits(
+    *,
+    primary_pct: float | None,
+    primary_reset: float | None,
+    secondary_pct: float | None,
+    secondary_reset: float | None,
+    model: str,
+    updated_at: datetime | None,
+) -> CodexRateLimits | None:
+    now_ts = datetime.now(UTC).timestamp()
+    if primary_reset is not None and primary_reset < now_ts:
+        primary_pct = None
+        primary_reset = None
+    if secondary_reset is not None and secondary_reset < now_ts:
+        secondary_pct = None
+        secondary_reset = None
+    if primary_pct is None and secondary_pct is None:
+        return None
+    return CodexRateLimits(
+        five_hour_pct=primary_pct,
+        five_hour_resets_at=primary_reset,
+        seven_day_pct=secondary_pct,
+        seven_day_resets_at=secondary_reset,
+        model=model,
+        updated_at=updated_at.isoformat() if updated_at is not None else "",
+    )
 
 
 def _load_thread_models() -> dict[str, str]:
@@ -225,7 +354,7 @@ _EVENT_VALUE_RE_CACHE: dict[str, re.Pattern[str]] = {}
 def _event_value(body: str, key: str) -> str:
     pattern = _EVENT_VALUE_RE_CACHE.get(key)
     if pattern is None:
-        pattern = re.compile(rf'(?:^|\s){re.escape(key)}=(?:"([^"]*)"|([^\s]+))')
+        pattern = re.compile(rf'(?:^|[\s{{]){re.escape(key)}=(?:"([^"]*)"|([^\s}}]+))')
         _EVENT_VALUE_RE_CACHE[key] = pattern
     match = pattern.search(body)
     if match is None:

--- a/menubar.py
+++ b/menubar.py
@@ -170,19 +170,28 @@ except (OSError, AttributeError):
 
 
 def _setup_fsevents(delegate: Any) -> Any:
-    """Start FSEventStream watching ~/.claude/; returns stream handle or None."""
+    """Start FSEventStream watching agent data directories; returns stream handle or None."""
     global _fs_callback_ref
     if not _FSEVENTS_AVAILABLE:
         return None
     try:
-        watch_path = str(Path.home() / ".claude")
-        cf_path = _cf_lib.CFStringCreateWithCString(
-            None,
-            watch_path.encode("utf-8"),
-            _kCFStringEncodingUTF8,
-        )
-        paths_arr = (ctypes.c_void_p * 1)(cf_path)
-        cf_paths = _cf_lib.CFArrayCreate(None, paths_arr, 1, None)
+        watch_paths = [
+            path
+            for path in (Path.home() / ".claude", Path.home() / ".codex")
+            if path.exists()
+        ]
+        if not watch_paths:
+            return None
+        cf_path_values = [
+            _cf_lib.CFStringCreateWithCString(
+                None,
+                str(path).encode("utf-8"),
+                _kCFStringEncodingUTF8,
+            )
+            for path in watch_paths
+        ]
+        paths_arr = (ctypes.c_void_p * len(cf_path_values))(*cf_path_values)
+        cf_paths = _cf_lib.CFArrayCreate(None, paths_arr, len(cf_path_values), None)
 
         def _on_fs_event(
             _stream: Any,
@@ -970,13 +979,21 @@ class AppDelegate(NSObject):
         sources = (
             Path.home() / ".claude",
             Path.home() / ".codex" / "sessions",
+            Path.home() / ".codex" / "logs_2.sqlite",
+            Path.home() / ".codex" / "logs_2.sqlite-wal",
+            Path.home() / ".codex" / "state_5.sqlite",
+            Path.home() / ".codex" / "state_5.sqlite-wal",
         )
         fingerprint: list[tuple[str, int, float]] = []
         for source in sources:
             newest_mtime = 0.0
             file_count = 0
             try:
-                if source.exists():
+                if source.is_file():
+                    stat = source.stat()
+                    file_count = 1
+                    newest_mtime = stat.st_mtime
+                elif source.exists():
                     for path in source.rglob("*.jsonl"):
                         try:
                             stat = path.stat()

--- a/subscription.py
+++ b/subscription.py
@@ -71,8 +71,6 @@ def _load_codex_subscription() -> dict[str, str | None] | None:
         return None
     if not isinstance(data, dict):
         return None
-    if data.get("auth_mode") != "chatgpt":
-        return None
     tokens = data.get("tokens")
     if not isinstance(tokens, dict):
         tokens = {}

--- a/tests/test_analyzer_pipeline.py
+++ b/tests/test_analyzer_pipeline.py
@@ -283,6 +283,7 @@ def test_report_today_uses_codex_token_count_deltas(
     codex_loader._jsonl_cache.clear()
     sessions_dir = tmp_path / "sessions"
     monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", tmp_path / "missing-logs.sqlite")
     monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {"session-1": "gpt-test"})
     now = datetime.now().astimezone()
     yesterday = now - timedelta(days=1)

--- a/tests/test_codex_consistency.py
+++ b/tests/test_codex_consistency.py
@@ -31,6 +31,7 @@ def test_codex_session_token_totals_match_between_delta_and_session_loaders(
     shutil.copyfile(FIXTURE, sessions_dir / FIXTURE.name)
 
     monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", tmp_path / "missing-logs.sqlite")
     monkeypatch.setattr(codex_adapter, "SESSIONS_DIR", str(sessions_dir))
     monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
     monkeypatch.setattr(codex_adapter, "_load_thread_models", lambda: {})

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -228,7 +228,12 @@ def _create_state_db(path: Path, rows: list[tuple[str, str, str]]) -> None:
         conn.executemany("INSERT INTO threads (id, model, cwd) VALUES (?, ?, ?)", rows)
 
 
-def _create_logs_db(path: Path, rows: list[tuple[int, int, str]]) -> None:
+def _create_logs_db(
+    path: Path,
+    rows: list[tuple[int, int, str]],
+    *,
+    target: str = "codex_otel.trace_safe",
+) -> None:
     with sqlite3.connect(path) as conn:
         conn.execute(
             "CREATE TABLE logs ("
@@ -249,7 +254,7 @@ def _create_logs_db(path: Path, rows: list[tuple[int, int, str]]) -> None:
             conn.execute(
                 "INSERT INTO logs (id, ts, ts_nanos, target, feedback_log_body) "
                 "VALUES (?, ?, ?, ?, ?)",
-                (row_id, ts, row_id * 10, "codex_otel.trace_safe", body),
+                (row_id, ts, row_id * 10, target, body),
             )
 
 
@@ -462,6 +467,81 @@ def test_load_rate_limits_reads_primary_and_secondary_windows(
         seven_day_pct=70.0,
         seven_day_resets_at=now.timestamp() + 120,
         model="gpt-test",
+        updated_at=now.isoformat(),
+    )
+
+
+def test_load_rate_limits_prefers_sqlite_websocket_rate_limits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    logs_db = tmp_path / "logs.sqlite"
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    stale_limits = _rate_limits()
+    stale_limits["primary"]["used_percent"] = 9
+    _write_rate_limit_session(
+        sessions_dir / "rate.jsonl",
+        now.isoformat(),
+        stale_limits,
+        now.timestamp(),
+    )
+    body = (
+        "session_loop{thread_id=session-sqlite}:turn{model=gpt-5.5}: "
+        'websocket event: {"type":"codex.rate_limits","plan_type":"plus",'
+        '"rate_limits":{"allowed":true,"limit_reached":false,'
+        '"primary":{"used_percent":40,"window_minutes":300,"reset_at":9999999999},'
+        '"secondary":{"used_percent":6,"window_minutes":10080,"reset_at":9999999998}},'
+        '"code_review_rate_limits":null}'
+    )
+    _create_logs_db(
+        logs_db,
+        [(1, int(now.timestamp()), body)],
+        target="codex_api::endpoint::responses_websocket",
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    result = codex_loader.load_rate_limits()
+
+    assert result == codex_loader.CodexRateLimits(
+        five_hour_pct=40.0,
+        five_hour_resets_at=9999999999.0,
+        seven_day_pct=6.0,
+        seven_day_resets_at=9999999998.0,
+        model="gpt-5.5",
+        updated_at=now.isoformat(),
+    )
+
+
+def test_load_rate_limits_reads_sqlite_usage_limit_error_headers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    logs_db = tmp_path / "logs.sqlite"
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    body = (
+        "session_loop{thread_id=session-error}:turn{model=gpt-5.4}: "
+        'websocket event: {"type":"error","error":{"type":"usage_limit_reached"},'
+        '"headers":{"X-Codex-Primary-Used-Percent":"100",'
+        '"X-Codex-Secondary-Used-Percent":"47",'
+        '"X-Codex-Primary-Reset-At":"9999999999",'
+        '"X-Codex-Secondary-Reset-At":"9999999998"}}'
+    )
+    _create_logs_db(
+        logs_db,
+        [(1, int(now.timestamp()), body)],
+        target="codex_api::endpoint::responses_websocket",
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", tmp_path / "missing-sessions")
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    result = codex_loader.load_rate_limits()
+
+    assert result == codex_loader.CodexRateLimits(
+        five_hour_pct=100.0,
+        five_hour_resets_at=9999999999.0,
+        seven_day_pct=47.0,
+        seven_day_resets_at=9999999998.0,
+        model="gpt-5.4",
         updated_at=now.isoformat(),
     )
 

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,10 @@ import codex_loader
 
 
 @pytest.fixture(autouse=True)
-def _clear_jsonl_cache() -> None:
+def _clear_jsonl_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     codex_loader._jsonl_cache.clear()
+    monkeypatch.setattr(codex_loader, "LOGS_DB", tmp_path / "missing-logs.sqlite")
+    monkeypatch.setattr(codex_loader, "STATE_DB", tmp_path / "missing-state.sqlite")
 
 
 def _write_session(
@@ -79,6 +82,7 @@ def test_load_entries_returns_empty_list_when_sessions_dir_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(codex_loader, "SESSIONS_DIR", tmp_path / "missing")
+    monkeypatch.setattr(codex_loader, "LOGS_DB", tmp_path / "missing.sqlite")
 
     assert codex_loader.load_entries() == []
 
@@ -90,8 +94,11 @@ def test_load_entries_parses_valid_jsonl_and_filters_by_hours_back(
     monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
     monkeypatch.setattr(
         codex_loader,
-        "_load_thread_models",
-        lambda: {"session-old": "gpt-test", "session-new": "gpt-test"},
+        "_load_thread_metadata",
+        lambda: {
+            "session-old": codex_loader._ThreadMetadata(model="gpt-test"),
+            "session-new": codex_loader._ThreadMetadata(model="gpt-test"),
+        },
     )
     old_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
     new_ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
@@ -213,6 +220,150 @@ def test_load_entries_splits_cumulative_usage_into_time_range_deltas(
     assert week_entries[0].input_tokens == 40
     assert week_entries[0].output_tokens == 30
     assert week_entries[0].cache_read_tokens == 10
+
+
+def _create_state_db(path: Path, rows: list[tuple[str, str, str]]) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE threads (id TEXT, model TEXT, cwd TEXT)")
+        conn.executemany("INSERT INTO threads (id, model, cwd) VALUES (?, ?, ?)", rows)
+
+
+def _create_logs_db(path: Path, rows: list[tuple[int, int, str]]) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE logs ("
+            "id INTEGER PRIMARY KEY, "
+            "ts INTEGER NOT NULL, "
+            "ts_nanos INTEGER NOT NULL, "
+            "level TEXT NOT NULL DEFAULT 'INFO', "
+            "target TEXT NOT NULL, "
+            "feedback_log_body TEXT, "
+            "module_path TEXT, "
+            "file TEXT, "
+            "line INTEGER, "
+            "thread_id TEXT, "
+            "process_uuid TEXT, "
+            "estimated_bytes INTEGER NOT NULL DEFAULT 0)"
+        )
+        for row_id, ts, body in rows:
+            conn.execute(
+                "INSERT INTO logs (id, ts, ts_nanos, target, feedback_log_body) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (row_id, ts, row_id * 10, "codex_otel.trace_safe", body),
+            )
+
+
+def _sqlite_token_body(
+    *,
+    session_id: str,
+    timestamp: str,
+    input_tokens: int,
+    output_tokens: int,
+    cached_tokens: int,
+    reasoning_tokens: int = 0,
+    model: str = "gpt-test",
+) -> str:
+    return (
+        'event.name="codex.sse_event" event.kind=response.completed '
+        f"input_token_count={input_tokens} output_token_count={output_tokens} "
+        f"cached_token_count={cached_tokens} reasoning_token_count={reasoning_tokens} "
+        f"tool_token_count={input_tokens + output_tokens} event.timestamp={timestamp} "
+        f"conversation.id={session_id} model={model}"
+    )
+
+
+def test_load_entries_includes_sqlite_logs_when_sessions_dir_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "missing-sessions"
+    state_db = tmp_path / "state.sqlite"
+    logs_db = tmp_path / "logs.sqlite"
+    timestamp = datetime.now(UTC).replace(microsecond=0)
+    _create_state_db(state_db, [("session-sqlite", "gpt-state", "/tmp/demo")])
+    _create_logs_db(
+        logs_db,
+        [
+            (
+                1,
+                int(timestamp.timestamp()),
+                _sqlite_token_body(
+                    session_id="session-sqlite",
+                    timestamp=timestamp.isoformat().replace("+00:00", "Z"),
+                    input_tokens=100,
+                    output_tokens=7,
+                    cached_tokens=20,
+                    reasoning_tokens=3,
+                ),
+            )
+        ],
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "STATE_DB", state_db)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    entries = codex_loader.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].timestamp == timestamp
+    assert entries[0].session_id == "session-sqlite"
+    assert entries[0].input_tokens == 80
+    assert entries[0].output_tokens == 10
+    assert entries[0].cache_read_tokens == 20
+    assert entries[0].total_tokens == 110
+    assert entries[0].project == "demo"
+
+
+def test_load_entries_skips_sqlite_logs_already_covered_by_jsonl(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    logs_db = tmp_path / "logs.sqlite"
+    old_ts = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    jsonl_ts = datetime(2026, 1, 1, 0, 5, tzinfo=UTC)
+    new_ts = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    _write_session(
+        sessions_dir / "session.jsonl",
+        session_id="same-session",
+        timestamp=jsonl_ts.isoformat(),
+        usage={"input_tokens": 20, "cached_input_tokens": 5, "output_tokens": 4},
+    )
+    _create_state_db(state_db, [("same-session", "gpt-state", "/tmp/demo")])
+    _create_logs_db(
+        logs_db,
+        [
+            (
+                1,
+                int(old_ts.timestamp()),
+                _sqlite_token_body(
+                    session_id="same-session",
+                    timestamp=old_ts.isoformat().replace("+00:00", "Z"),
+                    input_tokens=100,
+                    output_tokens=7,
+                    cached_tokens=20,
+                ),
+            ),
+            (
+                2,
+                int(new_ts.timestamp()),
+                _sqlite_token_body(
+                    session_id="same-session",
+                    timestamp=new_ts.isoformat().replace("+00:00", "Z"),
+                    input_tokens=50,
+                    output_tokens=3,
+                    cached_tokens=10,
+                ),
+            ),
+        ],
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "STATE_DB", state_db)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    entries = codex_loader.load_entries()
+
+    assert [entry.timestamp for entry in entries] == [jsonl_ts, new_ts]
+    assert [entry.total_tokens for entry in entries] == [24, 53]
 
 
 def test_parse_jsonl_skips_bad_lines_and_missing_fields(tmp_path: Path) -> None:

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -62,6 +62,21 @@ def test_codex_subscription(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     assert sub == {"agent": "Codex", "plan": "ChatGPT Plus", "since": "2026-03-23"}
 
 
+def test_codex_subscription_reads_plan_without_auth_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text(json.dumps({
+        "tokens": {"id_token": _make_id_token({
+            "chatgpt_plan_type": "plus",
+            "chatgpt_subscription_active_until": "2026-02-15T03:18:25+00:00",
+        })},
+    }))
+    monkeypatch.setattr(subscription, "CODEX_AUTH", auth)
+    sub = subscription._load_codex_subscription()
+    assert sub == {"agent": "Codex", "plan": "ChatGPT Plus", "since": None}
+
+
 def test_codex_api_key_mode_no_sub(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     auth = tmp_path / "auth.json"
     auth.write_text(json.dumps({"auth_mode": "apikey"}))


### PR DESCRIPTION
## Summary
- Add support for current Codex Desktop SQLite logs as a Codex usage source when session JSONL files are stale or missing.
- Prefer `codex.rate_limits` websocket events for current Codex quota, with JSONL `rate_limits` as fallback.
- Detect Codex ChatGPT subscription plan from JWT claims even when newer `auth.json` files omit `auth_mode`.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run pytest tests/`
- [x] Manually verified in menu bar mode / TUI mode (if UI-related)

## Notes for reviewer
- This stays offline/read-only and only reads local Codex state under `~/.codex`.
- `chatgpt_subscription_active_until` is intentionally not shown as subscribed-since because it is not a start date.
- SQLite log usage is appended only after the latest JSONL timestamp for the same session to avoid double counting overlap.
