### PR TITLE
fix: ignore echoed Codex quota queries

### DIFF
--- a/codex_loader.py
+++ b/codex_loader.py
@@ -128,9 +128,9 @@ def _load_sqlite_rate_limits() -> CodexRateLimits | None:
     query = (
         "SELECT ts, feedback_log_body FROM logs "
         "WHERE target = 'codex_api::endpoint::responses_websocket' "
-        "AND feedback_log_body LIKE '%websocket event:%' "
-        "AND (feedback_log_body LIKE '%\"type\":\"codex.rate_limits\"%' "
-        "OR feedback_log_body LIKE '%\"type\":\"error\"%usage_limit_reached%') "
+        "AND (feedback_log_body LIKE '%websocket event: {\"type\":\"codex.rate_limits\"%' "
+        "OR feedback_log_body LIKE "
+        "'%websocket event: {\"type\":\"error\"%usage_limit_reached%') "
         "ORDER BY ts DESC, ts_nanos DESC, id DESC LIMIT 50"
     )
     try:

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -557,6 +557,43 @@ def test_load_rate_limits_uses_newer_jsonl_when_sqlite_is_stale(
     )
 
 
+def test_load_rate_limits_ignores_websocket_command_echoes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    logs_db = tmp_path / "logs.sqlite"
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    noisy_rows = [
+        (
+            index,
+            int(now.timestamp()) + index,
+            'websocket event: {"type":"response.function_call_arguments.done",'
+            '"arguments":"sqlite query for \\"type\\":\\"codex.rate_limits\\""}',
+        )
+        for index in range(2, 82)
+    ]
+    body = (
+        "session_loop{thread_id=session-sqlite}:turn{model=gpt-5.5}: "
+        'websocket event: {"type":"codex.rate_limits","plan_type":"plus",'
+        '"rate_limits":{"allowed":true,"limit_reached":false,'
+        '"primary":{"used_percent":40,"window_minutes":300,"reset_at":9999999999},'
+        '"secondary":{"used_percent":6,"window_minutes":10080,"reset_at":9999999998}},'
+        '"code_review_rate_limits":null}'
+    )
+    _create_logs_db(
+        logs_db,
+        [(1, int(now.timestamp()), body), *noisy_rows],
+        target="codex_api::endpoint::responses_websocket",
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", tmp_path / "missing-sessions")
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    result = codex_loader.load_rate_limits()
+
+    assert result is not None
+    assert result.five_hour_pct == 40.0
+    assert result.seven_day_pct == 6.0
+
+
 def test_load_rate_limits_reads_sqlite_usage_limit_error_headers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- Narrow the Codex Desktop quota SQLite query so it only selects actual `websocket event: {"type":"codex.rate_limits"...}` and usage-limit error events.
- Avoid treating echoed tool-call arguments that mention `codex.rate_limits` as quota candidates, which can push real quota rows outside the scan window and temporarily hide the Codex card/title percentage.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run pytest tests/`
- [x] Manually verified in menu bar mode / TUI mode (if UI-related)

## Notes for reviewer
- This is a follow-up to #22. It keeps the same offline/read-only behavior and only tightens the SQL prefilter.
