### PR TITLE
fix: keep Codex quota refresh current

### DIFF
--- a/codex_loader.py
+++ b/codex_loader.py
@@ -100,6 +100,9 @@ def load_rate_limits() -> CodexRateLimits | None:
         return jsonl_limits
     if jsonl_limits is None:
         return sqlite_limits
+    merged = _merge_rate_limits(sqlite_limits, jsonl_limits)
+    if merged is not None:
+        return merged
     if _rate_limits_timestamp(jsonl_limits) > _rate_limits_timestamp(sqlite_limits):
         return jsonl_limits
     return sqlite_limits
@@ -120,6 +123,75 @@ def _load_jsonl_rate_limits() -> CodexRateLimits | None:
 def _rate_limits_timestamp(rate_limits: CodexRateLimits) -> datetime:
     parsed = _parse_timestamp(rate_limits.updated_at)
     return parsed if parsed is not None else datetime.min.replace(tzinfo=UTC)
+
+
+def _merge_rate_limits(
+    sqlite_limits: CodexRateLimits,
+    jsonl_limits: CodexRateLimits,
+) -> CodexRateLimits | None:
+    sqlite_ts = _rate_limits_timestamp(sqlite_limits)
+    jsonl_ts = _rate_limits_timestamp(jsonl_limits)
+    five_pct, five_reset = _pick_rate_limit_window(
+        sqlite_limits.five_hour_pct,
+        sqlite_limits.five_hour_resets_at,
+        sqlite_ts,
+        jsonl_limits.five_hour_pct,
+        jsonl_limits.five_hour_resets_at,
+        jsonl_ts,
+    )
+    seven_pct, seven_reset = _pick_rate_limit_window(
+        sqlite_limits.seven_day_pct,
+        sqlite_limits.seven_day_resets_at,
+        sqlite_ts,
+        jsonl_limits.seven_day_pct,
+        jsonl_limits.seven_day_resets_at,
+        jsonl_ts,
+    )
+    if five_pct is None and seven_pct is None:
+        return None
+    newer = jsonl_limits if jsonl_ts > sqlite_ts else sqlite_limits
+    return CodexRateLimits(
+        five_hour_pct=five_pct,
+        five_hour_resets_at=five_reset,
+        seven_day_pct=seven_pct,
+        seven_day_resets_at=seven_reset,
+        model=newer.model,
+        updated_at=newer.updated_at,
+    )
+
+
+def _pick_rate_limit_window(
+    sqlite_pct: float | None,
+    sqlite_reset: float | None,
+    sqlite_ts: datetime,
+    jsonl_pct: float | None,
+    jsonl_reset: float | None,
+    jsonl_ts: datetime,
+) -> tuple[float | None, float | None]:
+    if sqlite_pct is None:
+        return jsonl_pct, jsonl_reset
+    if jsonl_pct is None:
+        return sqlite_pct, sqlite_reset
+    if _active_window_limit_reached(sqlite_pct, sqlite_reset, jsonl_reset):
+        return sqlite_pct, sqlite_reset
+    if jsonl_ts > sqlite_ts:
+        return jsonl_pct, jsonl_reset
+    return sqlite_pct, sqlite_reset
+
+
+def _active_window_limit_reached(
+    sqlite_pct: float,
+    sqlite_reset: float | None,
+    jsonl_reset: float | None,
+) -> bool:
+    if sqlite_pct < 100:
+        return False
+    if sqlite_reset is None:
+        return True
+    if sqlite_reset is not None and sqlite_reset < datetime.now(UTC).timestamp():
+        return False
+    # A newer reset window means Codex has already moved past the 100% event.
+    return jsonl_reset is None or jsonl_reset <= sqlite_reset + 60
 
 
 def _load_sqlite_rate_limits() -> CodexRateLimits | None:

--- a/fsevents_watch.py
+++ b/fsevents_watch.py
@@ -103,7 +103,7 @@ def setup_fsevents(delegate: Any) -> Any:
             _flags: Any,
             _ids: Any,
         ) -> None:
-            delegate._refresh()
+            delegate._refresh(queue_if_busy=True)
 
         _fs_callback_ref = _FSEventStreamCallback(_on_fs_event)
         stream = _cs_lib.FSEventStreamCreate(

--- a/menubar.py
+++ b/menubar.py
@@ -383,7 +383,7 @@ class AppDelegate(NSObject):
         self._request_notification_authorization()
         self._refresh()
         self.timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-            300,
+            self.interval,
             self,
             "timerFired:",
             None,
@@ -758,13 +758,18 @@ class AppDelegate(NSObject):
         thread.start()
 
     def _refresh_in_background(self) -> None:
+        codex_result = self._load_codex_refresh_result()
+        self.performSelectorOnMainThread_withObject_waitUntilDone_(
+            "_applyCodexRefreshResult:",
+            codex_result,
+            False,
+        )
         try:
             outcome = asyncio.run(self._fetch())
-            codex_rows, codex_5h_pct, codex_model, codex_stale = menubar_state.codex_rows(
-                mock=self.mock,
-                language=self.language,
-                burn_rate_trackers=self.burn_rate_trackers,
-            )
+            codex_rows = codex_result["codex_rows"]
+            codex_5h_pct = codex_result["codex_5h_pct"]
+            codex_model = codex_result.get("codex_model", "unknown")
+            codex_stale = codex_result.get("codex_stale")
             all_entries = self._load_history_entries()
             project_rows = self._project_rows(hours_back=24, entries=all_entries)
             project_rows_7d = self._project_rows(hours_back=168, entries=all_entries)
@@ -828,6 +833,42 @@ class AppDelegate(NSObject):
             self._refresh_in_flight = False
         if should_refresh_again:
             self._refresh()
+
+    def _load_codex_refresh_result(self) -> dict[str, Any]:
+        try:
+            codex_rows, codex_5h_pct, codex_model, codex_stale = menubar_state.codex_rows(
+                mock=self.mock,
+                language=self.language,
+                burn_rate_trackers=self.burn_rate_trackers,
+            )
+        except Exception:
+            if os.environ.get("USAGE_DEBUG") == "1":
+                logger.warning("Codex quota refresh failed", exc_info=True)
+            codex_rows = (
+                _missing_row("Session", CODEX_COLOR, self.language),
+                _missing_row("Weekly", CODEX_COLOR, self.language),
+            )
+            codex_5h_pct = None
+            codex_model = "unknown"
+            codex_stale = None
+        return {
+            "codex_rows": codex_rows,
+            "codex_5h_pct": codex_5h_pct,
+            "codex_model": codex_model,
+            "codex_stale": codex_stale,
+        }
+
+    def _applyCodexRefreshResult_(self, result: dict[str, Any]) -> None:
+        codex_rows = result["codex_rows"]
+        self.latest_state.codex_session = codex_rows[0]
+        self.latest_state.codex_weekly = codex_rows[1]
+        self.latest_state.codex_stale = result.get("codex_stale")
+        self.codex_5h_pct = result["codex_5h_pct"]
+        self.codex_model = result.get("codex_model", "unknown")
+        if self.popover.isShown():
+            self.popover_controller.setState_(self.latest_state)
+        self.popover.setContentSize_(_popover_size(self.latest_state, self.active_panel))
+        self.status_item.button().setTitle_(self._compose_title(self.latest_state))
 
     def _request_notification_authorization(self) -> None:
         if self.mock or not _quota_notifications_enabled():
@@ -1103,7 +1144,7 @@ class AppDelegate(NSObject):
         )
         if self.codex_5h_pct is None:
             return base
-        return f"{base} · 📜 {self.codex_5h_pct}%"
+        return f"{base} · 📜 {_format_percent(float(self.codex_5h_pct))}%"
 
 
 def run_app(mock: bool = False, interval: int = 60) -> None:

--- a/menubar_state.py
+++ b/menubar_state.py
@@ -174,7 +174,7 @@ def codex_rows(
     mock: bool,
     language: str,
     burn_rate_trackers: dict[str, BurnRateTracker],
-) -> tuple[tuple[QuotaRowState, QuotaRowState], int | None, str, CodexStaleState | None]:
+) -> tuple[tuple[QuotaRowState, QuotaRowState], float | None, str, CodexStaleState | None]:
     if mock:
         now = time.time()
         burn_rate_trackers["codex_session"].record(now, 12.0)
@@ -228,9 +228,7 @@ def codex_rows(
         )
     except Exception:
         codex_stale = None
-    codex_5h_pct = (
-        round(rate_limits.five_hour_pct) if rate_limits.five_hour_pct is not None else None
-    )
+    codex_5h_pct = rate_limits.five_hour_pct
     if rate_limits.five_hour_pct is not None:
         burn_rate_trackers["codex_session"].record(now, rate_limits.five_hour_pct)
     if rate_limits.seven_day_pct is not None:

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -557,6 +557,91 @@ def test_load_rate_limits_uses_newer_jsonl_when_sqlite_is_stale(
     )
 
 
+def test_load_rate_limits_keeps_active_sqlite_limit_over_newer_jsonl_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    logs_db = tmp_path / "logs.sqlite"
+    old = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    new = datetime(2026, 1, 1, 12, 5, tzinfo=UTC)
+    reset_at = 9_999_999_999
+    stale_limits = _rate_limits()
+    stale_limits["primary"]["used_percent"] = 80
+    stale_limits["primary"]["resets_at"] = reset_at
+    _write_rate_limit_session(
+        sessions_dir / "rate.jsonl",
+        new.isoformat(),
+        stale_limits,
+        new.timestamp(),
+    )
+    body = (
+        "session_loop{thread_id=session-error}:turn{model=gpt-5.5}: "
+        'websocket event: {"type":"error","error":{"type":"usage_limit_reached"},'
+        '"headers":{"X-Codex-Primary-Used-Percent":"100",'
+        '"X-Codex-Secondary-Used-Percent":"16",'
+        f'"X-Codex-Primary-Reset-At":"{reset_at}",'
+        '"X-Codex-Secondary-Reset-At":"9999999998"}}'
+    )
+    _create_logs_db(
+        logs_db,
+        [(1, int(old.timestamp()), body)],
+        target="codex_api::endpoint::responses_websocket",
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    result = codex_loader.load_rate_limits()
+
+    assert result is not None
+    assert result.five_hour_pct == 100.0
+    assert result.five_hour_resets_at == float(reset_at)
+    assert result.seven_day_pct == 60.0
+    assert result.seven_day_resets_at == 9_999_999_999.0
+    assert result.updated_at == new.isoformat()
+
+
+def test_load_rate_limits_uses_newer_jsonl_after_sqlite_limit_reset_window(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    logs_db = tmp_path / "logs.sqlite"
+    old = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    new = datetime(2026, 1, 1, 12, 5, tzinfo=UTC)
+    old_reset_at = 9_999_999_000
+    new_reset_at = 9_999_999_999
+    new_limits = _rate_limits()
+    new_limits["primary"]["used_percent"] = 1
+    new_limits["primary"]["resets_at"] = new_reset_at
+    _write_rate_limit_session(
+        sessions_dir / "rate.jsonl",
+        new.isoformat(),
+        new_limits,
+        new.timestamp(),
+    )
+    body = (
+        "session_loop{thread_id=session-error}:turn{model=gpt-5.5}: "
+        'websocket event: {"type":"error","error":{"type":"usage_limit_reached"},'
+        '"headers":{"X-Codex-Primary-Used-Percent":"100",'
+        '"X-Codex-Secondary-Used-Percent":"16",'
+        f'"X-Codex-Primary-Reset-At":"{old_reset_at}",'
+        '"X-Codex-Secondary-Reset-At":"9999999998"}}'
+    )
+    _create_logs_db(
+        logs_db,
+        [(1, int(old.timestamp()), body)],
+        target="codex_api::endpoint::responses_websocket",
+    )
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+
+    result = codex_loader.load_rate_limits()
+
+    assert result is not None
+    assert result.five_hour_pct == 1.0
+    assert result.five_hour_resets_at == float(new_reset_at)
+    assert result.updated_at == new.isoformat()
+
+
 def test_load_rate_limits_ignores_websocket_command_echoes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -107,7 +107,7 @@ def _codex_rows(
     delegate: menubar.AppDelegate,
 ) -> tuple[
     tuple[menubar_state.QuotaRowState, menubar_state.QuotaRowState],
-    int | None,
+    float | None,
     str,
     menubar_state.CodexStaleState | None,
 ]:
@@ -1100,6 +1100,77 @@ def test_apply_refresh_result_pushes_state_only_when_popover_is_shown() -> None:
     assert delegate.latest_state == state
     assert delegate.codex_5h_pct == 34
     assert delegate._refresh_in_flight is False
+
+
+def test_apply_codex_refresh_result_updates_quota_before_full_refresh() -> None:
+    class FakeController:
+        def __init__(self) -> None:
+            self.calls: list[menubar.PopoverState] = []
+            self.content_view = object()
+
+        def setState_(self, state: menubar.PopoverState) -> None:
+            self.calls.append(state)
+
+    class FakePopover:
+        def __init__(self) -> None:
+            self.sizes: list[object] = []
+
+        def isShown(self) -> bool:
+            return True
+
+        def setContentSize_(self, size: object) -> None:
+            self.sizes.append(size)
+
+    class FakeButton:
+        def __init__(self) -> None:
+            self.titles: list[str] = []
+
+        def setTitle_(self, title: str) -> None:
+            self.titles.append(title)
+
+    class FakeStatusItem:
+        def __init__(self, button: FakeButton) -> None:
+            self._button = button
+
+        def button(self) -> FakeButton:
+            return self._button
+
+    delegate = menubar.AppDelegate.alloc().initWithMock_interval_(True, 60)
+    controller = FakeController()
+    button = FakeButton()
+    session = menubar_state.QuotaRowState(
+        title="Session",
+        percent=18.5,
+        percent_text="18.5% used",
+        reset_text="Resets in 2h",
+        color=menubar.CODEX_COLOR,
+    )
+    weekly = menubar_state.QuotaRowState(
+        title="Weekly",
+        percent=34.0,
+        percent_text="34% used",
+        reset_text="Resets in 6d",
+        color=menubar.CODEX_COLOR,
+    )
+    delegate.popover_controller = controller
+    delegate.popover = FakePopover()
+    delegate.status_item = FakeStatusItem(button)
+
+    delegate._applyCodexRefreshResult_(
+        {
+            "codex_rows": (session, weekly),
+            "codex_5h_pct": 18.5,
+            "codex_model": "gpt-test",
+            "codex_stale": None,
+        }
+    )
+
+    assert delegate.latest_state.codex_session == session
+    assert delegate.latest_state.codex_weekly == weekly
+    assert delegate.codex_5h_pct == 18.5
+    assert delegate.codex_model == "gpt-test"
+    assert controller.calls == [delegate.latest_state]
+    assert button.titles[-1].endswith("18.5%")
 
 
 def test_refresh_now_queues_when_refresh_is_busy() -> None:


### PR DESCRIPTION
## Summary
- merge Codex SQLite and JSONL quota snapshots per quota window instead of choosing one whole source
- keep an active SQLite 100% limit for the same reset window so the menu does not fall back to an older 80% snapshot
- keep weekly quota on the newer source when only the 5h window hit a limit
- show fractional Codex menu-bar percentages instead of rounding small usage to 0%
- apply Codex quota to the menu immediately at refresh start, before the heavier project-history pass finishes
- use the configured refresh interval instead of a hard-coded 300s timer, and queue FSEvents-triggered refreshes instead of dropping them while one is in flight

## Why
Codex writes quota snapshots to JSONL frequently, while project usage/history parsing can take longer and FSEvents can arrive while a refresh is already running. Previously the UI could look stale until another conversation event arrived, and manual refresh could appear ineffective because the quota update was delayed behind the full refresh pipeline.

## Tests
- .venv/bin/ruff check .
- .venv/bin/mypy .
- .venv/bin/python -m pytest tests/ -q