### PR TITLE
fix: preserve menu bar state on refresh failures

### DIFF
--- a/menubar.py
+++ b/menubar.py
@@ -895,12 +895,15 @@ class AppDelegate(NSObject):
                 codex_result,
                 False,
             )
+            fallback_state = getattr(self, "latest_state", _empty_state(self.language))
+            project_rows = list(fallback_state.projects)
+            project_rows_7d = list(fallback_state.projects_7d)
+            project_rows_30d = list(fallback_state.projects_30d)
+            project_rows_all = list(fallback_state.projects_all)
+            today_text = fallback_state.today_text
+            statusline = fallback_state.statusline
+            hide_codex = fallback_state.hide_codex
             try:
-                outcome = asyncio.run(self._fetch())
-                codex_rows = codex_result["codex_rows"]
-                codex_5h_pct = codex_result["codex_5h_pct"]
-                codex_model = codex_result.get("codex_model", "unknown")
-                codex_stale = codex_result.get("codex_stale")
                 all_entries = self._load_history_entries()
                 project_rows = self._project_rows(hours_back=24, entries=all_entries)
                 project_rows_7d = self._project_rows(hours_back=168, entries=all_entries)
@@ -908,10 +911,19 @@ class AppDelegate(NSObject):
                 project_rows_all = self._project_rows(hours_back=0, entries=all_entries)
                 today_text = _today_title(self.mock, self.language, entries=all_entries)
                 statusline = _statusline_payload(self.language)
+                hide_codex = _hide_codex_enabled()
+            except Exception:
+                if os.environ.get("USAGE_DEBUG") == "1":
+                    logger.warning("local usage refresh failed", exc_info=True)
+            try:
+                outcome = asyncio.run(self._fetch())
+                codex_rows = codex_result["codex_rows"]
+                codex_5h_pct = codex_result["codex_5h_pct"]
+                codex_model = codex_result.get("codex_model", "unknown")
+                codex_stale = codex_result.get("codex_stale")
                 show_install_button = (
                     outcome.state == PollState.TOKEN_ERROR and self._statusline_setup_available()
                 )
-                hide_codex = _hide_codex_enabled()
                 group = self.tracker.group()
                 state = menubar_state.build_popover_state(
                     outcome=outcome,
@@ -939,6 +951,13 @@ class AppDelegate(NSObject):
                 state.codex_session = codex_rows[0]
                 state.codex_weekly = codex_rows[1]
                 state.codex_stale = codex_result.get("codex_stale")
+                state.projects = project_rows
+                state.projects_7d = project_rows_7d
+                state.projects_30d = project_rows_30d
+                state.projects_all = project_rows_all
+                state.today_text = today_text
+                state.statusline = statusline
+                state.hide_codex = hide_codex
 
             result = {"state": state, "codex_5h_pct": codex_5h_pct, "codex_model": codex_model}
             self.performSelectorOnMainThread_withObject_waitUntilDone_(

--- a/menubar.py
+++ b/menubar.py
@@ -200,6 +200,23 @@ _CODEX_MENUBAR_ICON: Any = None
 _CODEX_MENUBAR_ICON_LOADED = False
 
 
+class _NoopAlert:
+    def setIcon_(self, icon: Any) -> None:
+        return
+
+    def setMessageText_(self, text: str) -> None:
+        return
+
+    def setInformativeText_(self, text: str) -> None:
+        return
+
+    def addButtonWithTitle_(self, title: str) -> None:
+        return
+
+    def runModal(self) -> int:
+        return 0
+
+
 def _alert_icon() -> Any:
     # NSAlert defaults to the application icon, which from source (and for an
     # accessory app with no Dock presence) is py2app's / Python's rocket. Setting
@@ -259,10 +276,23 @@ def _menubar_icon_attachment_string(image: Any) -> Any:
 
 
 def _make_alert() -> Any:
-    alert = NSAlert.alloc().init()
+    try:
+        alert = NSAlert.alloc().init()
+    except Exception:
+        if os.environ.get("USAGE_DEBUG") == "1":
+            logger.warning("create alert failed", exc_info=True)
+        return _NoopAlert()
+    if alert is None:
+        if os.environ.get("USAGE_DEBUG") == "1":
+            logger.warning("create alert returned None")
+        return _NoopAlert()
     icon = _alert_icon()
     if icon is not None:
-        alert.setIcon_(icon)
+        try:
+            alert.setIcon_(icon)
+        except Exception:
+            if os.environ.get("USAGE_DEBUG") == "1":
+                logger.warning("set alert icon failed", exc_info=True)
     return alert
 
 

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -1391,6 +1391,88 @@ def test_refresh_error_preserves_codex_quota() -> None:
     assert result["codex_model"] == "gpt-test"
 
 
+def test_refresh_error_preserves_project_usage() -> None:
+    captured: dict[str, object] = {}
+    session = menubar_state.QuotaRowState(
+        title="Session",
+        percent=1.0,
+        percent_text="1% used",
+        reset_text="Resets in 4h",
+        color=menubar.CODEX_COLOR,
+    )
+    weekly = menubar_state.QuotaRowState(
+        title="Weekly",
+        percent=37.0,
+        percent_text="37% used",
+        reset_text="Resets in 5d",
+        color=menubar.CODEX_COLOR,
+    )
+    entries = [
+        history_loader.UsageEntry(
+            timestamp=datetime.now(tz=UTC),
+            session_id="session",
+            message_id="message",
+            request_id="request",
+            model="gpt-5-codex",
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_tokens=10,
+            cache_read_tokens=5,
+            cost_usd=0.01,
+            project="Eric-Tools",
+        )
+    ]
+
+    class Delegate:
+        mock = False
+        language = "en"
+        latest_state = menubar._empty_state(language="en")
+
+        def _load_codex_refresh_result(self) -> dict[str, object]:
+            return {
+                "codex_rows": (session, weekly),
+                "codex_5h_pct": 1.0,
+                "codex_model": "gpt-test",
+                "codex_stale": None,
+            }
+
+        def _load_history_entries(self) -> list[history_loader.UsageEntry]:
+            return entries
+
+        def _project_rows(
+            self,
+            hours_back: int = 24,
+            entries: list[history_loader.UsageEntry] | None = None,
+        ) -> list[tuple[str, int, float | None]]:
+            return menubar.AppDelegate._project_rows(
+                cast(Any, self),
+                hours_back=hours_back,
+                entries=entries,
+            )
+
+        def performSelectorOnMainThread_withObject_waitUntilDone_(
+            self, selector: str, result: dict[str, object], wait: bool
+        ) -> None:
+            captured["selector"] = selector
+            captured["result"] = result
+            captured["wait"] = wait
+
+        async def _fetch(self) -> PollOutcome:
+            raise RuntimeError("fetch failed")
+
+    menubar.AppDelegate._refresh_in_background(cast(Any, Delegate()))
+
+    result = captured["result"]
+    assert isinstance(result, dict)
+    state = result["state"]
+    assert isinstance(state, menubar_state.PopoverState)
+    assert state.projects == [("Eric-Tools", 165, 0.01)]
+    assert state.projects_7d == [("Eric-Tools", 165, 0.01)]
+    assert state.projects_30d == [("Eric-Tools", 165, 0.01)]
+    assert state.projects_all == [("Eric-Tools", 165, 0.01)]
+    assert "165 tokens" in state.today_text
+
+
 def test_refresh_now_queues_when_refresh_is_busy() -> None:
     delegate = menubar.AppDelegate.alloc().initWithMock_interval_(True, 60)
     delegate._refresh_in_flight = True

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -807,6 +807,47 @@ def test_forwarder_prompt_enable_calls_forwarder_setup(
     assert data["usage"]["forwarderModePromptDismissed"] is True
 
 
+def test_make_alert_falls_back_when_nsalert_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeAlert:
+        @classmethod
+        def alloc(cls) -> type[FakeAlert]:
+            return cls
+
+        @classmethod
+        def init(cls) -> None:
+            return None
+
+    monkeypatch.setattr(menubar, "NSAlert", FakeAlert)
+
+    alert = menubar._make_alert()
+
+    alert.setMessageText_("ignored")
+    alert.setInformativeText_("ignored")
+    alert.addButtonWithTitle_("ignored")
+    assert alert.runModal() == 0
+
+
+def test_make_alert_ignores_icon_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeAlert:
+        @classmethod
+        def alloc(cls) -> type[FakeAlert]:
+            return cls
+
+        @classmethod
+        def init(cls) -> FakeAlert:
+            return cls()
+
+        def setIcon_(self, value: object) -> None:
+            raise RuntimeError("icon failed")
+
+    monkeypatch.setattr(menubar, "NSAlert", FakeAlert)
+    monkeypatch.setattr(menubar, "_alert_icon", lambda: object())
+
+    assert isinstance(menubar._make_alert(), FakeAlert)
+
+
 def test_statusline_action_in_background_returns_failure_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add a no-op alert fallback when `NSAlert` creation returns `None` or raises.
- Ignore alert icon assignment failures so AppKit alert setup does not interrupt menu bar UI updates.
- Load local project usage before the remote usage fetch, and preserve project rows/today/statusline if that fetch fails.
- Cover alert fallback and refresh-error project preservation with menubar tests.

## Test plan
- [x] `.venv/bin/ruff check menubar.py tests/test_menubar.py`
- [x] `.venv/bin/mypy menubar.py tests/test_menubar.py`
- [x] `.venv/bin/python -m pytest tests/test_menubar.py -q`
- [x] Manually verified the rebuilt menu bar app recovers project usage instead of staying empty after the failure path

## Notes for reviewer
The key behavior is that local Codex/project usage should not disappear just because alert setup or the remote fetch path fails. Normal alerts still use `NSAlert`; the no-op object is only used when alert construction fails. Icon failures are logged only in `USAGE_DEBUG=1` mode.