### PR TITLE
fix: map Project Usage 30d reports to last30

### DIFF
--- a/menubar.py
+++ b/menubar.py
@@ -1314,6 +1314,8 @@ def _analysis_period_from_project_range(project_range: str) -> str:
         return "today"
     if project_range == "7d":
         return "week"
+    if project_range == "30d":
+        return "last30"
     if project_range == "all":
         return "all"
     return "month"

--- a/tests/test_analyzer_pipeline.py
+++ b/tests/test_analyzer_pipeline.py
@@ -177,13 +177,13 @@ def test_app_analyze_uses_project_range_period(
     delegate.analyzeUsage_(None)
     delegate.analyzeUsage_("all")
 
-    assert calls == ["month", "all"]
+    assert calls == ["last30", "all"]
 
 
 def test_analysis_period_from_project_range() -> None:
     assert menubar._analysis_period_from_project_range("1d") == "today"
     assert menubar._analysis_period_from_project_range("7d") == "week"
-    assert menubar._analysis_period_from_project_range("30d") == "month"
+    assert menubar._analysis_period_from_project_range("30d") == "last30"
     assert menubar._analysis_period_from_project_range("all") == "all"
 
 


### PR DESCRIPTION
## Summary
- Map the Project Usage `30d` Analyze action to the report pipeline's `last30` period.
- Keep `month` as the explicit current-month report period for CLI/report callers.
- Update analyzer pipeline tests for the Project Usage period mapping.

## Test plan
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mypy .`
- [x] `.venv/bin/python -m pytest tests/`
- [x] `.venv/bin/python -m pytest tests/test_analyzer_pipeline.py -q`
- [x] Manually verified in menu bar mode by rebuilding/restarting the app bundle

## Notes for reviewer
The menu bar Project Usage chip labels `30d` as a rolling 30-day range, while the report pipeline treats `month` as the current calendar month. This PR connects that UI action to `last30` so the HTML report matches the selected Project Usage range.

`uv` is not installed in my local environment, so I ran the equivalent commands through the project virtualenv.