### PR TITLE
fix: apply Codex quota refresh before history scan

### DIFF
--- a/menubar.py
+++ b/menubar.py
@@ -893,7 +893,7 @@ class AppDelegate(NSObject):
             self.performSelectorOnMainThread_withObject_waitUntilDone_(
                 "_applyCodexRefreshResult:",
                 codex_result,
-                False,
+                True,
             )
             fallback_state = getattr(self, "latest_state", _empty_state(self.language))
             project_rows = list(fallback_state.projects)

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -1342,6 +1342,7 @@ def test_apply_codex_refresh_result_updates_quota_before_full_refresh() -> None:
 
 def test_refresh_error_preserves_codex_quota() -> None:
     captured: dict[str, object] = {}
+    calls: list[tuple[str, bool]] = []
     session = menubar_state.QuotaRowState(
         title="Session",
         percent=1.0,
@@ -1372,6 +1373,7 @@ def test_refresh_error_preserves_codex_quota() -> None:
         def performSelectorOnMainThread_withObject_waitUntilDone_(
             self, selector: str, result: dict[str, object], wait: bool
         ) -> None:
+            calls.append((selector, wait))
             captured["selector"] = selector
             captured["result"] = result
             captured["wait"] = wait
@@ -1389,6 +1391,10 @@ def test_refresh_error_preserves_codex_quota() -> None:
     assert state.codex_weekly == weekly
     assert result["codex_5h_pct"] == 1.0
     assert result["codex_model"] == "gpt-test"
+    assert calls == [
+        ("_applyCodexRefreshResult:", True),
+        ("_applyRefreshResult:", False),
+    ]
 
 
 def test_refresh_error_preserves_project_usage() -> None:


### PR DESCRIPTION
## Summary
- Apply the interim Codex quota refresh on the main thread synchronously before continuing the heavier project history scan.
- Keep the full refresh path asynchronous as before.
- Add test coverage for the interim quota update ordering.

## Why
Codex quota loading is fast, but project history refresh can be much heavier because it may scan all-time usage and SQLite logs after a source fingerprint change. Previously the interim Codex quota state was posted to the main thread with waitUntilDone=False, so the background refresh could immediately continue into the heavier history work before the menubar UI had applied the fresh quota. That made Codex usage look stale until a later event or another message caused another refresh.

## Test plan
- [x] .venv/bin/python -m pytest tests/test_menubar.py -q
- [x] .venv/bin/ruff check menubar.py tests/test_menubar.py
- [x] .venv/bin/mypy menubar.py tests/test_menubar.py
- [ ] uv run pytest tests/
