### PR TITLE
fix: scan Codex rate limit files by mtime

### DIFF
--- a/codex_loader.py
+++ b/codex_loader.py
@@ -468,77 +468,19 @@ def _timestamp_from_log_ts(value: Any) -> datetime | None:
 
 
 def _recent_jsonl_files() -> list[Path]:
-    paths = _recent_jsonl_files_from_date_dirs()
-    if paths is None:
-        paths = list(SESSIONS_DIR.rglob("*.jsonl"))
+    try:
+        paths = [path for path in SESSIONS_DIR.rglob("*.jsonl") if _is_visible_jsonl(path)]
+    except OSError:
+        return []
     return _sort_recent_jsonl_files(paths)
 
 
-# This relies on Codex writing sessions under their creation date. A long session
-# from an older day that is still appended can differ from a full rglob if newer
-# date dirs already contain the scan limit; full elimination would require the
-# expensive all-tree scan this path avoids.
-def _recent_jsonl_files_from_date_dirs() -> list[Path] | None:
-    paths: list[Path] = []
-    years = _sorted_date_dirs(SESSIONS_DIR, 4)
-    if years is None:
-        return None
-    for year in years:
-        months = _sorted_date_dirs(Path(year.path), 2)
-        if months is None:
-            return None
-        for month in months:
-            days = _sorted_date_dirs(Path(month.path), 2)
-            if days is None:
-                return None
-            for day in days:
-                day_paths = _jsonl_files_in_day_dir(Path(day.path))
-                if day_paths is None:
-                    return None
-                paths.extend(day_paths)
-                if len(paths) >= _RECENT_JSONL_SCAN_LIMIT:
-                    return paths
-    return paths
-
-
-def _sorted_date_dirs(parent: Path, name_length: int) -> list[os.DirEntry[str]] | None:
-    dirs: list[os.DirEntry[str]] = []
+def _is_visible_jsonl(path: Path) -> bool:
     try:
-        with os.scandir(parent) as entries:
-            for entry in entries:
-                if entry.name.startswith("."):
-                    continue
-                try:
-                    if not entry.is_dir():
-                        return None
-                except OSError:
-                    return None
-                if len(entry.name) != name_length or not entry.name.isdigit():
-                    return None
-                dirs.append(entry)
-    except OSError:
-        return None
-    dirs.sort(key=lambda entry: entry.name, reverse=True)
-    return dirs
-
-
-def _jsonl_files_in_day_dir(day_dir: Path) -> list[Path] | None:
-    paths: list[Path] = []
-    try:
-        with os.scandir(day_dir) as entries:
-            for entry in entries:
-                if entry.name.startswith("."):
-                    continue
-                try:
-                    if entry.is_dir():
-                        return None
-                    if entry.is_file() and entry.name.endswith(".jsonl"):
-                        paths.append(Path(entry.path))
-                except OSError:
-                    return None
-    except OSError:
-        return None
-    return paths
+        relative = path.relative_to(SESSIONS_DIR)
+    except ValueError:
+        return False
+    return all(not part.startswith(".") for part in relative.parts)
 
 
 def _sort_recent_jsonl_files(paths: list[Path]) -> list[Path]:

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -898,7 +898,7 @@ def test_load_rate_limits_picks_most_recent_valid(monkeypatch: pytest.MonkeyPatc
     assert result.updated_at == new_ts
 
 
-def test_recent_jsonl_files_matches_full_scan_for_date_dirs(
+def test_recent_jsonl_files_sorts_visible_sessions_by_mtime(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     sessions_dir = tmp_path / "sessions"
@@ -929,7 +929,30 @@ def test_recent_jsonl_files_matches_full_scan_for_date_dirs(
     assert codex_loader._recent_jsonl_files() == expected
 
 
-def test_recent_jsonl_files_ignores_dotfiles_without_fallback(
+def test_recent_jsonl_files_keeps_newest_file_even_if_older_date_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    for index in range(codex_loader._RECENT_JSONL_SCAN_LIMIT + 5):
+        _write_rate_limit_session(
+            sessions_dir / "2026" / "06" / "12" / f"session-{index:02}.jsonl",
+            "2026-06-12T15:38:27+00:00",
+            None,
+            1_000 + index,
+        )
+    important = sessions_dir / "2026" / "05" / "25" / "important.jsonl"
+    _write_rate_limit_session(
+        important,
+        "2026-06-13T03:39:36+00:00",
+        _rate_limits(),
+        9_999,
+    )
+
+    assert important in codex_loader._recent_jsonl_files()
+
+
+def test_recent_jsonl_files_ignores_dotfiles(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     sessions_dir = tmp_path / "sessions"
@@ -968,7 +991,7 @@ def test_recent_jsonl_files_ignores_dotfiles_without_fallback(
     assert codex_loader._recent_jsonl_files() == expected
 
 
-def test_recent_jsonl_files_falls_back_for_unexpected_structure(
+def test_recent_jsonl_files_includes_non_date_directories(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     sessions_dir = tmp_path / "sessions"


### PR DESCRIPTION
## Summary
- Restore mtime-based selection for recent Codex session jsonl files used by rate-limit loading.
- Keep dotfile filtering so hidden files under `~/.codex/sessions` are ignored.
- Add regression coverage for an older date directory containing the newest modified session file.

## Why
`_recent_jsonl_files()` was optimized to walk Codex date directories newest-first and stop once the scan limit was reached. That assumes the active session lives under one of the newest date directories, but long-lived Codex sessions can keep appending to an older creation-date directory. When enough newer date-dir files exist, the actually newest modified session file is skipped, so the menu bar can keep showing stale 5h quota values.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_codex_loader.py -q`
- [x] `.venv/bin/ruff check codex_loader.py tests/test_codex_loader.py`
- [x] `.venv/bin/mypy codex_loader.py tests/test_codex_loader.py`
- [ ] `uv run pytest tests/`

## Notes for reviewer
- This intentionally reverts the rate-limit file picker to a global mtime sort. The scan still only parses the top `_RECENT_JSONL_SCAN_LIMIT` candidates after sorting.
- The broader project-history loading path is unchanged. This only affects which session files are considered for current Codex quota snapshots.
