### PR TITLE
fix: read Codex model from turn context

### DIFF
--- a/adapters/codex.py
+++ b/adapters/codex.py
@@ -69,6 +69,7 @@ def _load_thread_models() -> dict[str, str]:
 
 def _extract_rate_limits(path: Path, models: dict[str, str]) -> RateLimits | None:
     session_id = ""
+    session_model = "unknown"
     last_rl = None
     try:
         rows = _load_jsonl_rows(path)
@@ -78,7 +79,11 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> RateLimits | Non
 
     for data in rows:
         if data.get("type") == "session_meta":
-            session_id = data.get("payload", {}).get("id", "")
+            payload = data.get("payload", {})
+            session_id = payload.get("id", "")
+            session_model = _session_model(payload, session_model)
+        if data.get("type") == "turn_context":
+            session_model = _session_model(data.get("payload"), session_model)
         if data.get("type") != "event_msg":
             continue
         payload = data.get("payload", {})
@@ -118,7 +123,7 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> RateLimits | Non
         five_hour_resets_at=five_reset,
         seven_day_pct=seven_pct,
         seven_day_resets_at=seven_reset,
-        model=model_name,
+        model=model_name or session_model,
         updated_at=ts,
     )
 
@@ -163,7 +168,11 @@ def _parse_jsonl(
             cwd = payload.get("cwd", "")
             if cwd:
                 project = _project_from_cwd(cwd)
-            model = models.get(session_id, "unknown")
+            model = models.get(session_id) or _session_model(payload, model)
+            continue
+
+        if row_type == "turn_context":
+            model = models.get(session_id) or _session_model(data.get("payload"), model)
             continue
 
         if row_type != "event_msg":
@@ -253,6 +262,13 @@ def _as_optional_float(value: Any) -> float | None:
     if not math.isfinite(number):
         return None
     return number
+
+
+def _session_model(payload: Any, fallback: str) -> str:
+    model = payload.get("model") if isinstance(payload, dict) else ""
+    if not isinstance(model, str):
+        model = ""
+    return model or fallback
 
 
 def _as_int(value: Any) -> int:

--- a/codex_loader.py
+++ b/codex_loader.py
@@ -496,6 +496,7 @@ def _sort_recent_jsonl_files(paths: list[Path]) -> list[Path]:
 
 def _extract_rate_limits(path: Path, models: dict[str, str]) -> CodexRateLimits | None:
     session_id = ""
+    session_model = "unknown"
     last_rate_limits: tuple[dict[str, Any], str] | None = None
     try:
         with path.open(encoding="utf-8") as file:
@@ -505,6 +506,10 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> CodexRateLimits 
                     continue
                 if data.get("type") == "session_meta":
                     session_id = _as_str(_as_dict(data.get("payload")).get("id"))
+                    session_model = _session_model(data.get("payload"), session_model)
+                    continue
+                if data.get("type") == "turn_context":
+                    session_model = _session_model(data.get("payload"), session_model)
                     continue
                 if data.get("type") != "event_msg":
                     continue
@@ -540,7 +545,7 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> CodexRateLimits 
         five_hour_resets_at=five_reset,
         seven_day_pct=seven_pct,
         seven_day_resets_at=seven_reset,
-        model=models.get(session_id, "unknown"),
+        model=models.get(session_id, session_model),
         updated_at=updated_at,
     )
 
@@ -557,7 +562,8 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
         _jsonl_cache.move_to_end(path)
         cached_entries = cache_entry[2]
         for entry in cached_entries:
-            entry.model = models.get(entry.session_id, "unknown")
+            if entry.session_id in models:
+                entry.model = models[entry.session_id]
         if cutoff is None:
             return cached_entries
         return [entry for entry in cached_entries if entry.timestamp >= cutoff]
@@ -565,6 +571,7 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
     session_id = ""
     session_timestamp = ""
     project = "unknown"
+    session_model = "unknown"
     entries: list[UsageEntry] = []
     previous_usage: _TokenUsage | None = None
     token_count_index = 0
@@ -579,6 +586,10 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
                     session_id = _as_str(payload.get("id"))
                     session_timestamp = _as_str(payload.get("timestamp"))
                     project = _project_from_cwd(_as_str(payload.get("cwd")))
+                    session_model = _session_model(payload, session_model)
+                    continue
+                if data.get("type") == "turn_context":
+                    session_model = _session_model(data.get("payload"), session_model)
                     continue
                 if data.get("type") != "event_msg":
                     continue
@@ -601,7 +612,7 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
                         session_id=session_id,
                         message_id=f"{session_id}:{token_count_index}",
                         request_id="",
-                        model=models.get(session_id, "unknown"),
+                        model=models.get(session_id, session_model),
                         input_tokens=delta.input_tokens,
                         output_tokens=delta.output_tokens,
                         cache_creation_tokens=0,
@@ -688,6 +699,11 @@ def _project_from_cwd(cwd: str) -> str:
 
 def _as_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _session_model(payload: Any, fallback: str) -> str:
+    model = _as_str(_as_dict(payload).get("model"))
+    return model or fallback
 
 
 def _as_int(value: Any) -> int:

--- a/tests/test_adapters_codex.py
+++ b/tests/test_adapters_codex.py
@@ -53,6 +53,42 @@ def _write_session(
         os.utime(path, (mtime, mtime))
 
 
+def _write_session_with_turn_context_model(
+    path: Path,
+    *,
+    session_id: str,
+    timestamp: str,
+    model: str,
+    usage: dict[str, Any],
+    rate_limits: dict[str, Any] | None = None,
+    mtime: float | None = None,
+    cwd: str = "/tmp/demo",
+) -> None:
+    lines = [
+        {
+            "type": "session_meta",
+            "payload": {"id": session_id, "timestamp": timestamp, "cwd": cwd},
+        },
+        {
+            "type": "turn_context",
+            "payload": {"model": model, "cwd": cwd},
+        },
+        {
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": {
+                "type": "token_count",
+                "info": {"total_token_usage": usage},
+                "rate_limits": rate_limits,
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
 def test_loaders_skip_bad_utf8_jsonl_without_crashing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -116,3 +152,74 @@ def test_load_entries_accepts_numeric_string_usage_fields(
     assert entries[0].input_tokens == 8
     assert entries[0].output_tokens == 7
     assert entries[0].cache_read_tokens == 2
+
+
+def test_load_entries_uses_turn_context_model_when_state_db_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    timestamp = datetime.now(UTC).isoformat()
+    _write_session_with_turn_context_model(
+        sessions_dir / "turn-context.jsonl",
+        session_id="turn-context",
+        timestamp=timestamp,
+        model="gpt-5.4-mini",
+        usage={"input_tokens": 10, "cached_input_tokens": 2, "output_tokens": 3},
+    )
+    monkeypatch.setattr(codex, "SESSIONS_DIR", str(sessions_dir))
+    monkeypatch.setattr(codex, "_load_thread_models", lambda: {})
+
+    entries = codex.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].model == "gpt-5.4-mini"
+
+
+def test_load_entries_prefers_state_db_model_over_turn_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    timestamp = datetime.now(UTC).isoformat()
+    _write_session_with_turn_context_model(
+        sessions_dir / "turn-context.jsonl",
+        session_id="turn-context",
+        timestamp=timestamp,
+        model="gpt-5.4-mini",
+        usage={"input_tokens": 10, "cached_input_tokens": 2, "output_tokens": 3},
+    )
+    monkeypatch.setattr(codex, "SESSIONS_DIR", str(sessions_dir))
+    monkeypatch.setattr(codex, "_load_thread_models", lambda: {"turn-context": "gpt-state"})
+
+    entries = codex.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].model == "gpt-state"
+
+
+def test_extract_rate_limits_uses_turn_context_model_when_state_db_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    now = datetime.now(UTC)
+    _write_session_with_turn_context_model(
+        sessions_dir / "turn-context-rate.jsonl",
+        session_id="turn-context-rate",
+        timestamp=now.isoformat(),
+        model="gpt-5.4-mini",
+        usage={"input_tokens": 1},
+        rate_limits={
+            "primary": {"used_percent": 25, "resets_at": now.timestamp() + 60},
+            "secondary": {"used_percent": 70, "resets_at": now.timestamp() + 120},
+        },
+        mtime=now.timestamp(),
+    )
+    monkeypatch.setattr(codex, "SESSIONS_DIR", str(sessions_dir))
+    monkeypatch.setattr(codex, "_load_thread_models", lambda: {})
+
+    result = codex._extract_rate_limits(sessions_dir / "turn-context-rate.jsonl", {})
+
+    assert result is not None
+    assert result.model == "gpt-5.4-mini"

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -84,6 +84,42 @@ def _write_session_with_usage_events(
     path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
 
 
+def _write_session_with_turn_context_model(
+    path: Path,
+    *,
+    session_id: str,
+    timestamp: str,
+    model: str,
+    usage: dict[str, Any],
+    rate_limits: dict[str, Any] | None = None,
+    mtime: float | None = None,
+    cwd: str = "/tmp/demo",
+) -> None:
+    lines = [
+        {
+            "type": "session_meta",
+            "payload": {"id": session_id, "timestamp": timestamp, "cwd": cwd},
+        },
+        {
+            "type": "turn_context",
+            "payload": {"model": model, "cwd": cwd},
+        },
+        {
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": {
+                "type": "token_count",
+                "info": {"total_token_usage": usage},
+                "rate_limits": rate_limits,
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
 def test_load_entries_returns_empty_list_when_sessions_dir_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1050,6 +1086,46 @@ def test_load_entries_accepts_numeric_string_usage_fields(
     assert entries[0].cache_read_tokens == 2
 
 
+def test_load_entries_uses_turn_context_model_when_state_db_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    timestamp = datetime.now(UTC).isoformat()
+    _write_session_with_turn_context_model(
+        sessions_dir / "turn-context.jsonl",
+        session_id="turn-context",
+        timestamp=timestamp,
+        model="gpt-5.4-mini",
+        usage={"input_tokens": 10, "cached_input_tokens": 2, "output_tokens": 3},
+    )
+
+    entries = codex_loader.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].model == "gpt-5.4-mini"
+
+
+def test_load_entries_cache_keeps_turn_context_model_when_state_db_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    timestamp = datetime.now(UTC).isoformat()
+    _write_session_with_turn_context_model(
+        sessions_dir / "turn-context.jsonl",
+        session_id="turn-context",
+        timestamp=timestamp,
+        model="gpt-5.4-mini",
+        usage={"input_tokens": 10, "cached_input_tokens": 2, "output_tokens": 3},
+    )
+
+    assert codex_loader.load_entries()[0].model == "gpt-5.4-mini"
+    assert codex_loader.load_entries()[0].model == "gpt-5.4-mini"
+
+
 def test_load_rate_limits_accepts_numeric_string_fields(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1072,3 +1148,35 @@ def test_load_rate_limits_accepts_numeric_string_fields(
     assert result is not None
     assert result.five_hour_pct == 25.0
     assert result.seven_day_pct == 70.0
+
+
+def test_load_rate_limits_uses_turn_context_model_when_state_db_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    now = datetime.now(UTC)
+    _write_session_with_turn_context_model(
+        sessions_dir / "turn-context-rate.jsonl",
+        session_id="turn-context-rate",
+        timestamp=now.isoformat(),
+        model="gpt-5.4-mini",
+        usage={"input_tokens": 1},
+        rate_limits={
+            "primary": {"used_percent": 25, "resets_at": now.timestamp() + 60},
+            "secondary": {"used_percent": 70, "resets_at": now.timestamp() + 120},
+        },
+        mtime=now.timestamp(),
+    )
+
+    result = codex_loader.load_rate_limits()
+
+    assert result == codex_loader.CodexRateLimits(
+        five_hour_pct=25.0,
+        five_hour_resets_at=now.timestamp() + 60,
+        seven_day_pct=70.0,
+        seven_day_resets_at=now.timestamp() + 120,
+        model="gpt-5.4-mini",
+        updated_at=now.isoformat(),
+    )


### PR DESCRIPTION
## Summary
- Read Codex session model metadata from JSONL `turn_context` records when `state_5.sqlite` does not have a thread row.
- Apply the same fallback to current rate-limit snapshots and historical usage entries.
- Keep `state_5.sqlite` as the preferred source when it has a model, and preserve JSONL fallback models across `codex_loader` cache hits.

## Why
Recent Codex sessions can contain the active model in the session JSONL as `turn_context.payload.model` while `~/.codex/state_5.sqlite` has no matching thread metadata row. In that case usage entries fell back to `unknown`, so cost estimates returned `$0` and model breakdowns were less accurate even though the source data contained the model.

This does not add pricing for `codex-auto-review`. That slug is present in Codex's local model cache as an automatic approval review model, but it does not appear in the LiteLLM pricing table and there is no verifiable public unit price to map it to safely.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_codex_loader.py tests/test_adapters_codex.py tests/test_codex_consistency.py`
- [x] `.venv/bin/python -m ruff check codex_loader.py adapters/codex.py tests/test_codex_loader.py tests/test_adapters_codex.py`
- [x] `.venv/bin/python -m mypy codex_loader.py adapters/codex.py tests/test_codex_loader.py tests/test_adapters_codex.py`
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m mypy .`
- [ ] `.venv/bin/python -m pytest tests/` aborts locally in `tests/test_panels.py` while initializing AppKit/WebKit views; before that abort, two `tests/test_menubar.py` assertions are affected by my local persisted `hide_claude_section` preference.

## Notes for reviewer
- `state_5.sqlite` still wins when it has thread model metadata.
- The new fallback is limited to existing local Codex session data; it does not call any remote API.
- The legacy `adapters/codex.py` path is updated too so both Codex loaders resolve model metadata consistently.
