### PR TITLE
fix: preserve panel quota rows across updates

### DIFF
--- a/assets/panels/aquarium.html
+++ b/assets/panels/aquarium.html
@@ -773,14 +773,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim();
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/black_hole.html
+++ b/assets/panels/black_hole.html
@@ -669,14 +669,17 @@
       const available = data.available === true && typeof data.percent === "number";
       const alertColor = colorFor(data.percent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/classic.html
+++ b/assets/panels/classic.html
@@ -664,14 +664,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim();
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/cloud_observation.html
+++ b/assets/panels/cloud_observation.html
@@ -763,14 +763,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim();
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/lepidoptera.html
+++ b/assets/panels/lepidoptera.html
@@ -928,14 +928,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim();
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/matrix.html
+++ b/assets/panels/matrix.html
@@ -641,14 +641,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim() || MATRIX_GREEN;
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/newspaper.html
+++ b/assets/panels/newspaper.html
@@ -619,14 +619,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim();
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/prism_arcade.html
+++ b/assets/panels/prism_arcade.html
@@ -699,14 +699,17 @@
       const available = data.available === true && typeof data.percent === "number";
       const alertColor = colorFor(data.percent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/assets/panels/win95.html
+++ b/assets/panels/win95.html
@@ -586,14 +586,17 @@
       const accent = getComputedStyle(cardEl).getPropertyValue("--accent").trim();
       const color = colorFor(data.percent, accent);
       el.dataset.available = available ? "true" : "false";
-      el.innerHTML = `
-        <div class="row-head">
-          <div class="row-title"></div>
-          <div class="percent"></div>
-        </div>
-        <div class="track"><div class="fill"></div></div>
-        <div class="reset"></div>
-      `;
+      if (el.dataset.rowReady !== "true") {
+        el.innerHTML = `
+          <div class="row-head">
+            <div class="row-title"></div>
+            <div class="percent"></div>
+          </div>
+          <div class="track"><div class="fill"></div></div>
+          <div class="reset"></div>
+        `;
+        el.dataset.rowReady = "true";
+      }
       const title = el.querySelector(".row-title");
       const percent = el.querySelector(".percent");
       const reset = el.querySelector(".reset");

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -102,6 +102,18 @@ def test_html_panels_place_analyze_and_cli_in_project_header() -> None:
         assert 'class="action" data-action="analyze"' not in html
 
 
+def test_html_panel_rows_are_initialized_once() -> None:
+    panel_dir = Path(__file__).resolve().parent.parent / "assets" / "panels"
+
+    for panel_path in sorted(panel_dir.glob("*.html")):
+        html = panel_path.read_text(encoding="utf-8")
+        if "function renderRow(" not in html:
+            continue
+
+        assert 'el.dataset.rowReady !== "true"' in html, panel_path.name
+        assert 'el.dataset.rowReady = "true"' in html, panel_path.name
+
+
 def test_classic_project_header_expands_for_action_row() -> None:
     panel_path = Path(__file__).resolve().parent.parent / "assets" / "panels" / "classic.html"
     html = panel_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Keep quota row DOM nodes mounted after the first render in HTML panels that use `renderRow()`.
- Continue updating row title, percentage, reset text, warning state, fill width, and color on every state injection.
- Add a panel regression test so future theme changes do not reintroduce per-update row reconstruction.

## Why
Some themes have animated quota tracks, such as the Session and Weekly sweep in Prism Arcade, Black Hole, and Aquarium. The panel state injection path updates the existing WKWebView, but each duplicated `renderRow()` implementation rebuilt the row `innerHTML` on every state update. Recreating the track restarts its CSS animation, which can make the quota rows look like they flash too frequently when refreshes, file events, or manual updates occur.

This keeps the current theme styling and animation behavior, but prevents ordinary state updates from restarting the track animation.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_panels.py`
- [x] `.venv/bin/python -m ruff check assets tests/test_panels.py`
- [x] `git diff --check`
- [ ] `.venv/bin/python -m pytest tests/test_menubar.py tests/test_panels.py` has 2 local `tests/test_menubar.py` failures in persisted Claude/setup state expectations; `tests/test_panels.py` passes.

## Notes for reviewer
- This is intentionally scoped to preserving row DOM across state injections.
- It does not slow down or remove any theme animation.
- `world_cup.html` uses a separate duel renderer, so it is not changed by this PR.