### PR TITLE
fix: correct Codex fork and reasoning usage accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 All notable changes to usage are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+- **Forked Codex conversations no longer replay parent history as new usage**: Codex can embed a timestamp-rewritten copy of the parent conversation in a fork JSONL. The loader now matches and excludes that replay while retaining both the original parent usage and new post-fork usage.
+- **Codex reasoning tokens are no longer charged twice**: `reasoning_output_tokens` is already included in Codex's `output_tokens`, so JSONL and SQLite usage readers now price the output total once.
+
 ## [0.20.2] - 2026-06-16
 
 ### Fixed

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -4,6 +4,12 @@
 
 本檔記錄 usage 所有重要變更。格式參考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## 尚未發布
+
+### 修正
+- **Fork 後的 Codex 對話不再把父對話歷史重播算成新用量**：Codex 可能在 fork JSONL 內嵌一份 timestamp 被重寫的父對話副本。讀取器現在會比對並排除這段重播，同時保留父對話原始用量與 fork 後真正新增的用量。
+- **Codex reasoning token 不再重複計價**：`reasoning_output_tokens` 已包含於 Codex 的 `output_tokens`，JSONL 與 SQLite 用量讀取器現在只會計算一次輸出總量。
+
 ## [0.20.2] - 2026-06-16
 
 ### 修正

--- a/adapters/codex.py
+++ b/adapters/codex.py
@@ -9,11 +9,13 @@ import math
 import os
 import sqlite3
 import sys
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+import codex_loader as shared_codex_loader
 
 from .types import AgentInfo, RateLimits, UsageEntry
 
@@ -36,23 +38,40 @@ def detect() -> AgentInfo | None:
 
 
 def load_entries(hours_back: int = 0) -> list[UsageEntry]:
-    entries: list[UsageEntry] = []
-    seen: set[str] = set()
     cutoff = None
     if hours_back > 0:
         cutoff = datetime.now(timezone.utc) - timedelta(hours=hours_back)
 
     models = _load_thread_models()
-
     sessions_path = Path(SESSIONS_DIR)
-    if not sessions_path.is_dir():
-        return entries
+    delta_entries = shared_codex_loader._load_jsonl_entries(sessions_path, models, cutoff)
+    by_session: dict[str, list[Any]] = defaultdict(list)
+    for entry in delta_entries:
+        by_session[entry.session_id].append(entry)
 
-    for jsonl_path in sessions_path.rglob("*.jsonl"):
-        _parse_jsonl(jsonl_path, models, entries, seen, cutoff)
-
+    entries = [_aggregate_session(session_entries) for session_entries in by_session.values()]
     entries.sort(key=lambda e: e.timestamp)
     return entries
+
+
+def _aggregate_session(session_entries: list[Any]) -> UsageEntry:
+    first = session_entries[0]
+    primary = max(session_entries, key=lambda entry: entry.total_tokens)
+    return UsageEntry(
+        timestamp=first.timestamp,
+        session_id=first.session_id,
+        message_id=first.session_id,
+        request_id="",
+        model=primary.model,
+        input_tokens=sum(entry.input_tokens for entry in session_entries),
+        output_tokens=sum(entry.output_tokens for entry in session_entries),
+        cache_creation_tokens=sum(entry.cache_creation_tokens for entry in session_entries),
+        cache_read_tokens=sum(entry.cache_read_tokens for entry in session_entries),
+        cost_usd=None,
+        project=first.project,
+        agent_id="codex",
+        message_count=len(session_entries),
+    )
 
 
 def _load_thread_models() -> dict[str, str]:
@@ -128,104 +147,6 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> RateLimits | Non
     )
 
 
-def _project_from_cwd(cwd: str) -> str:
-    home = os.path.expanduser("~")
-    if cwd.startswith(home):
-        rel = cwd[len(home):].strip(os.sep)
-    else:
-        rel = cwd.strip(os.sep)
-    parts = rel.split(os.sep)
-    return parts[-1] if parts and parts[-1] else rel or "unknown"
-
-
-def _parse_jsonl(
-    path: Path,
-    models: dict[str, str],
-    entries: list[UsageEntry],
-    seen: set[str],
-    cutoff: datetime | None,
-) -> None:
-    session_id = ""
-    session_ts = ""
-    project = "unknown"
-    model = "unknown"
-    last_usage = None
-    msg_count = 0
-
-    try:
-        rows = _load_jsonl_rows(path)
-    except (OSError, PermissionError, UnicodeDecodeError) as exc:
-        _debug_file_error("failed to read Codex session log", path, exc)
-        return
-
-    for data in rows:
-        row_type = data.get("type")
-
-        if row_type == "session_meta":
-            payload = data.get("payload", {})
-            session_id = payload.get("id", "")
-            session_ts = payload.get("timestamp", "")
-            cwd = payload.get("cwd", "")
-            if cwd:
-                project = _project_from_cwd(cwd)
-            model = models.get(session_id) or _session_model(payload, model)
-            continue
-
-        if row_type == "turn_context":
-            model = models.get(session_id) or _session_model(data.get("payload"), model)
-            continue
-
-        if row_type != "event_msg":
-            continue
-
-        payload = data.get("payload", {})
-        if payload.get("type") == "token_count":
-            info = payload.get("info")
-            if info and info.get("total_token_usage"):
-                last_usage = info["total_token_usage"]
-                msg_count += 1
-
-    if not last_usage or not session_id:
-        return
-
-    cached = _as_int(last_usage.get("cached_input_tokens"))
-    input_tokens = _as_int(last_usage.get("input_tokens")) - cached
-    output_tokens = _as_int(last_usage.get("output_tokens")) + _as_int(
-        last_usage.get("reasoning_output_tokens")
-    )
-
-    if input_tokens == 0 and output_tokens == 0:
-        return
-
-    try:
-        ts = datetime.fromisoformat(session_ts.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        return
-
-    if cutoff and ts < cutoff:
-        return
-
-    if session_id in seen:
-        return
-    seen.add(session_id)
-
-    entries.append(UsageEntry(
-        timestamp=ts,
-        session_id=session_id,
-        message_id=session_id,
-        request_id="",
-        model=model,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_creation_tokens=0,
-        cache_read_tokens=cached,
-        cost_usd=None,
-        project=project,
-        agent_id="codex",
-        message_count=msg_count,
-    ))
-
-
 def _load_jsonl_rows(path: Path) -> list[dict[str, Any]]:
     st = path.stat()
     cached = _file_cache.get(path)
@@ -269,13 +190,6 @@ def _session_model(payload: Any, fallback: str) -> str:
     if not isinstance(model, str):
         model = ""
     return model or fallback
-
-
-def _as_int(value: Any) -> int:
-    number = _as_optional_float(value)
-    if number is None:
-        return 0
-    return int(number)
 
 
 def _as_optional_int(value: Any) -> int | None:

--- a/codex_loader.py
+++ b/codex_loader.py
@@ -418,9 +418,7 @@ def _parse_sqlite_log_row(
         return None
     cached = _as_int(_event_value(body, "cached_token_count"))
     input_tokens = max(0, _as_int(_event_value(body, "input_token_count")) - cached)
-    output_tokens = _as_int(_event_value(body, "output_token_count")) + _as_int(
-        _event_value(body, "reasoning_token_count")
-    )
+    output_tokens = _as_int(_event_value(body, "output_token_count"))
     if input_tokens + output_tokens + cached == 0:
         return None
     thread = metadata.get(session_id, _ThreadMetadata())
@@ -663,9 +661,7 @@ class _TokenUsage:
 def _token_usage_from_payload(usage: dict[str, Any]) -> _TokenUsage:
     cached = _as_int(usage.get("cached_input_tokens"))
     input_tokens = max(0, _as_int(usage.get("input_tokens")) - cached)
-    output_tokens = _as_int(usage.get("output_tokens")) + _as_int(
-        usage.get("reasoning_output_tokens"),
-    )
+    output_tokens = _as_int(usage.get("output_tokens"))
     return _TokenUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,

--- a/codex_loader.py
+++ b/codex_loader.py
@@ -26,7 +26,16 @@ logger = logging.getLogger(__name__)
 
 _JSONL_CACHE_MAXSIZE = 512
 _RECENT_JSONL_SCAN_LIMIT = 30
-_jsonl_cache: OrderedDict[Path, tuple[float, int, list[UsageEntry]]] = OrderedDict()
+_ReplayCacheKey = tuple[str, float, int, int] | None
+_jsonl_cache: OrderedDict[
+    Path,
+    tuple[float, int, _ReplayCacheKey, list[UsageEntry]],
+] = OrderedDict()
+_ReplayLookupKey = tuple[float, int, tuple[tuple[str, float, int], ...]]
+_fork_replay_cache: OrderedDict[
+    Path,
+    tuple[_ReplayLookupKey, int | None, _ReplayCacheKey],
+] = OrderedDict()
 
 SESSIONS_DIR = Path(os.path.expanduser("~/.codex/sessions"))
 STATE_DB = Path(os.path.expanduser("~/.codex/state_5.sqlite"))
@@ -49,43 +58,77 @@ class _ThreadMetadata:
     cwd: str = ""
 
 
+@dataclass(frozen=True, slots=True)
+class _SessionFileInfo:
+    session_id: str = ""
+    forked_from_id: str = ""
+
+
 def load_entries(hours_back: int = 0) -> list[UsageEntry]:
-    entries_by_session: dict[str, list[UsageEntry]] = {}
     cutoff = datetime.now(UTC) - timedelta(hours=hours_back) if hours_back > 0 else None
-    cutoff_ts = cutoff.timestamp() if cutoff else None
     metadata = _load_thread_metadata()
     models = {session_id: data.model for session_id, data in metadata.items()}
-
-    if SESSIONS_DIR.is_dir():
-        for jsonl_path in SESSIONS_DIR.rglob("*.jsonl"):
-            if cutoff_ts is not None:
-                try:
-                    if jsonl_path.stat().st_mtime < cutoff_ts:
-                        continue
-                except OSError as exc:
-                    logger.warning("failed to stat session log %s: %s", jsonl_path, exc)
-                    continue
-            parsed = _parse_jsonl(jsonl_path, models, cutoff)
-            if not parsed:
-                continue
-            existing = entries_by_session.get(parsed[0].session_id)
-            if existing is None or _is_better_session_log(parsed, existing):
-                entries_by_session[parsed[0].session_id] = parsed
+    entries = _load_jsonl_entries(SESSIONS_DIR, models, cutoff)
 
     latest_jsonl_ts_by_session = {
-        session_id: session_entries[-1].timestamp
-        for session_id, session_entries in entries_by_session.items()
-        if session_entries
+        entry.session_id: entry.timestamp
+        for entry in entries
     }
+    entries.extend(_load_sqlite_log_entries(metadata, cutoff, latest_jsonl_ts_by_session))
+    entries.sort(key=lambda entry: entry.timestamp)
+    return entries
 
-    entries = [
+
+def _load_jsonl_entries(
+    sessions_dir: Path,
+    models: dict[str, str],
+    cutoff: datetime | None,
+) -> list[UsageEntry]:
+    if not sessions_dir.is_dir():
+        return []
+
+    entries_by_session: dict[str, list[UsageEntry]] = {}
+    cutoff_ts = cutoff.timestamp() if cutoff else None
+    jsonl_paths = list(sessions_dir.rglob("*.jsonl"))
+    file_info = {path: _read_session_file_info(path) for path in jsonl_paths}
+    paths_by_session: dict[str, list[Path]] = {}
+    for path, info in file_info.items():
+        if info.session_id:
+            paths_by_session.setdefault(info.session_id, []).append(path)
+
+    for jsonl_path in jsonl_paths:
+        if cutoff_ts is not None:
+            try:
+                if jsonl_path.stat().st_mtime < cutoff_ts:
+                    continue
+            except OSError as exc:
+                logger.warning("failed to stat session log %s: %s", jsonl_path, exc)
+                continue
+        info = file_info[jsonl_path]
+        replay_boundary, replay_cache_key = _fork_replay_boundary(
+            jsonl_path,
+            info,
+            paths_by_session.get(info.forked_from_id, []),
+        )
+        parsed = _parse_jsonl(
+            jsonl_path,
+            models,
+            cutoff,
+            file_info=info,
+            replay_boundary=replay_boundary,
+            replay_cache_key=replay_cache_key,
+        )
+        if not parsed:
+            continue
+        existing = entries_by_session.get(parsed[0].session_id)
+        if existing is None or _is_better_session_log(parsed, existing):
+            entries_by_session[parsed[0].session_id] = parsed
+
+    return [
         entry
         for session_entries in entries_by_session.values()
         for entry in session_entries
     ]
-    entries.extend(_load_sqlite_log_entries(metadata, cutoff, latest_jsonl_ts_by_session))
-    entries.sort(key=lambda entry: entry.timestamp)
-    return entries
 
 
 def _is_better_session_log(candidate: list[UsageEntry], existing: list[UsageEntry]) -> bool:
@@ -98,6 +141,23 @@ def _is_better_session_log(candidate: list[UsageEntry], existing: list[UsageEntr
 
 def _session_total_tokens(entries: list[UsageEntry]) -> int:
     return sum(entry.total_tokens for entry in entries)
+
+
+def _read_session_file_info(path: Path) -> _SessionFileInfo:
+    try:
+        with path.open(encoding="utf-8") as file:
+            for line in file:
+                data = _load_json_line(line)
+                if data is None or data.get("type") != "session_meta":
+                    continue
+                payload = _as_dict(data.get("payload"))
+                return _SessionFileInfo(
+                    session_id=_as_str(payload.get("id")),
+                    forked_from_id=_as_str(payload.get("forked_from_id")),
+                )
+    except (OSError, UnicodeDecodeError):
+        return _SessionFileInfo()
+    return _SessionFileInfo()
 
 
 def load_rate_limits() -> CodexRateLimits | None:
@@ -548,7 +608,165 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> CodexRateLimits 
     )
 
 
-def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) -> list[UsageEntry]:
+def _fork_replay_boundary(
+    path: Path,
+    info: _SessionFileInfo,
+    parent_paths: list[Path],
+) -> tuple[int | None, _ReplayCacheKey]:
+    if not info.forked_from_id:
+        return 0, None
+
+    # Fork logs rewrite replay timestamps, but preserve the parent's cumulative token sequence.
+    lookup_key = _fork_replay_lookup_key(path, parent_paths)
+    if lookup_key is None:
+        return None, None
+    cached = _fork_replay_cache.get(path)
+    if cached is not None and cached[0] == lookup_key:
+        _fork_replay_cache.move_to_end(path)
+        return cached[1], cached[2]
+
+    child_events = _token_usage_events_after_embedded_parent(path, info.forked_from_id)
+    if child_events is None:
+        result: tuple[int | None, _ReplayCacheKey] = (0, None)
+        _cache_fork_replay_boundary(path, lookup_key, result)
+        return result
+    if not lookup_key[2]:
+        result = (None, None)
+        _cache_fork_replay_boundary(path, lookup_key, result)
+        return result
+
+    child_usage = [usage for _, usage in child_events]
+    best_match = 0
+    best_key: _ReplayCacheKey = None
+    for parent_path in parent_paths:
+        match_count = _common_prefix_length(
+            child_usage,
+            _raw_token_usage_sequence(parent_path),
+        )
+        if match_count <= best_match:
+            continue
+        try:
+            parent_stat = parent_path.stat()
+        except OSError:
+            continue
+        best_match = match_count
+        best_key = (
+            str(parent_path),
+            parent_stat.st_mtime,
+            parent_stat.st_size,
+            match_count,
+        )
+
+    if child_events and best_match == 0:
+        result = (None, None)
+        _cache_fork_replay_boundary(path, lookup_key, result)
+        return result
+    boundary = child_events[best_match - 1][0] if best_match else 0
+    result = (boundary, best_key)
+    _cache_fork_replay_boundary(path, lookup_key, result)
+    return result
+
+
+def _fork_replay_lookup_key(
+    path: Path,
+    parent_paths: list[Path],
+) -> _ReplayLookupKey | None:
+    try:
+        child_stat = path.stat()
+    except OSError:
+        return None
+    parent_stats: list[tuple[str, float, int]] = []
+    for parent_path in parent_paths:
+        try:
+            parent_stat = parent_path.stat()
+        except OSError:
+            continue
+        parent_stats.append((str(parent_path), parent_stat.st_mtime, parent_stat.st_size))
+    return child_stat.st_mtime, child_stat.st_size, tuple(sorted(parent_stats))
+
+
+def _cache_fork_replay_boundary(
+    path: Path,
+    lookup_key: _ReplayLookupKey,
+    result: tuple[int | None, _ReplayCacheKey],
+) -> None:
+    if path not in _fork_replay_cache and len(_fork_replay_cache) >= _JSONL_CACHE_MAXSIZE:
+        _fork_replay_cache.popitem(last=False)
+    _fork_replay_cache[path] = (lookup_key, result[0], result[1])
+
+
+def _token_usage_events_after_embedded_parent(
+    path: Path,
+    parent_session_id: str,
+) -> list[tuple[int, _TokenUsage]] | None:
+    embedded_parent = False
+    root_seen = False
+    events: list[tuple[int, _TokenUsage]] = []
+    try:
+        with path.open(encoding="utf-8") as file:
+            for line_number, line in enumerate(file, start=1):
+                data = _load_json_line(line)
+                if data is None:
+                    continue
+                if data.get("type") == "session_meta":
+                    session_id = _as_str(_as_dict(data.get("payload")).get("id"))
+                    if not root_seen:
+                        root_seen = True
+                    elif session_id == parent_session_id:
+                        embedded_parent = True
+                    continue
+                usage = _token_usage_from_event(data)
+                if embedded_parent and usage is not None:
+                    events.append((line_number, usage))
+    except (OSError, UnicodeDecodeError):
+        return None
+    return events if embedded_parent else None
+
+
+def _raw_token_usage_sequence(path: Path) -> list[_TokenUsage]:
+    usage_events: list[_TokenUsage] = []
+    try:
+        with path.open(encoding="utf-8") as file:
+            for line in file:
+                data = _load_json_line(line)
+                if data is None:
+                    continue
+                usage = _token_usage_from_event(data)
+                if usage is not None:
+                    usage_events.append(usage)
+    except (OSError, UnicodeDecodeError):
+        return []
+    return usage_events
+
+
+def _token_usage_from_event(data: dict[str, Any]) -> _TokenUsage | None:
+    if data.get("type") != "event_msg":
+        return None
+    payload = _as_dict(data.get("payload"))
+    if payload.get("type") != "token_count":
+        return None
+    usage = _as_dict(_as_dict(payload.get("info")).get("total_token_usage"))
+    return _token_usage_from_payload(usage) if usage else None
+
+
+def _common_prefix_length(left: list[_TokenUsage], right: list[_TokenUsage]) -> int:
+    matched = 0
+    for left_usage, right_usage in zip(left, right, strict=False):
+        if left_usage != right_usage:
+            break
+        matched += 1
+    return matched
+
+
+def _parse_jsonl(
+    path: Path,
+    models: dict[str, str],
+    cutoff: datetime | None,
+    *,
+    file_info: _SessionFileInfo | None = None,
+    replay_boundary: int | None = 0,
+    replay_cache_key: _ReplayCacheKey = None,
+) -> list[UsageEntry]:
     try:
         st = path.stat()
     except OSError as exc:
@@ -556,9 +774,14 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
         return []
 
     cache_entry = _jsonl_cache.get(path)
-    if cache_entry is not None and cache_entry[0] == st.st_mtime and cache_entry[1] == st.st_size:
+    if (
+        cache_entry is not None
+        and cache_entry[0] == st.st_mtime
+        and cache_entry[1] == st.st_size
+        and cache_entry[2] == replay_cache_key
+    ):
         _jsonl_cache.move_to_end(path)
-        cached_entries = cache_entry[2]
+        cached_entries = cache_entry[3]
         for entry in cached_entries:
             if entry.session_id in models:
                 entry.model = models[entry.session_id]
@@ -566,7 +789,11 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
             return cached_entries
         return [entry for entry in cached_entries if entry.timestamp >= cutoff]
 
-    session_id = ""
+    info = file_info or _read_session_file_info(path)
+    if replay_boundary is None:
+        return []
+
+    session_id = info.session_id
     session_timestamp = ""
     project = "unknown"
     session_model = "unknown"
@@ -575,16 +802,18 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
     token_count_index = 0
     try:
         with path.open(encoding="utf-8") as file:
-            for line in file:
+            for line_number, line in enumerate(file, start=1):
                 data = _load_json_line(line)
                 if data is None:
                     continue
                 if data.get("type") == "session_meta":
                     payload = _as_dict(data.get("payload"))
-                    session_id = _as_str(payload.get("id"))
-                    session_timestamp = _as_str(payload.get("timestamp"))
-                    project = _project_from_cwd(_as_str(payload.get("cwd")))
-                    session_model = _session_model(payload, session_model)
+                    if not session_timestamp:
+                        session_timestamp = _as_str(payload.get("timestamp"))
+                        project = _project_from_cwd(_as_str(payload.get("cwd")))
+                        session_model = _session_model(payload, session_model)
+                    continue
+                if line_number <= replay_boundary:
                     continue
                 if data.get("type") == "turn_context":
                     session_model = _session_model(data.get("payload"), session_model)
@@ -623,16 +852,16 @@ def _parse_jsonl(path: Path, models: dict[str, str], cutoff: datetime | None) ->
         logger.warning("failed to parse codex session %s: %s", path, exc)
         if path not in _jsonl_cache and len(_jsonl_cache) >= _JSONL_CACHE_MAXSIZE:
             _jsonl_cache.popitem(last=False)
-        _jsonl_cache[path] = (st.st_mtime, st.st_size, [])
+        _jsonl_cache[path] = (st.st_mtime, st.st_size, replay_cache_key, [])
         return []
     if not entries and session_timestamp:
         if path not in _jsonl_cache and len(_jsonl_cache) >= _JSONL_CACHE_MAXSIZE:
             _jsonl_cache.popitem(last=False)
-        _jsonl_cache[path] = (st.st_mtime, st.st_size, [])
+        _jsonl_cache[path] = (st.st_mtime, st.st_size, replay_cache_key, [])
         return []
     if path not in _jsonl_cache and len(_jsonl_cache) >= _JSONL_CACHE_MAXSIZE:
         _jsonl_cache.popitem(last=False)
-    _jsonl_cache[path] = (st.st_mtime, st.st_size, entries)
+    _jsonl_cache[path] = (st.st_mtime, st.st_size, replay_cache_key, entries)
     if cutoff is not None:
         return [entry for entry in entries if entry.timestamp >= cutoff]
     return entries

--- a/tests/test_adapters_codex.py
+++ b/tests/test_adapters_codex.py
@@ -150,7 +150,7 @@ def test_load_entries_accepts_numeric_string_usage_fields(
 
     assert len(entries) == 1
     assert entries[0].input_tokens == 8
-    assert entries[0].output_tokens == 7
+    assert entries[0].output_tokens == 3
     assert entries[0].cache_read_tokens == 2
 
 

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -257,10 +257,10 @@ def test_load_entries_splits_cumulative_usage_into_time_range_deltas(
     all_entries = codex_loader.load_entries()
     week_entries = codex_loader.load_entries(hours_back=168)
 
-    assert [entry.total_tokens for entry in all_entries] == [160, 80]
-    assert [entry.total_tokens for entry in week_entries] == [80]
+    assert [entry.total_tokens for entry in all_entries] == [160, 70]
+    assert [entry.total_tokens for entry in week_entries] == [70]
     assert week_entries[0].input_tokens == 40
-    assert week_entries[0].output_tokens == 30
+    assert week_entries[0].output_tokens == 20
     assert week_entries[0].cache_read_tokens == 10
 
 
@@ -354,9 +354,9 @@ def test_load_entries_includes_sqlite_logs_when_sessions_dir_is_missing(
     assert entries[0].timestamp == timestamp
     assert entries[0].session_id == "session-sqlite"
     assert entries[0].input_tokens == 80
-    assert entries[0].output_tokens == 10
+    assert entries[0].output_tokens == 7
     assert entries[0].cache_read_tokens == 20
-    assert entries[0].total_tokens == 110
+    assert entries[0].total_tokens == 107
     assert entries[0].project == "demo"
 
 
@@ -1082,7 +1082,7 @@ def test_load_entries_accepts_numeric_string_usage_fields(
 
     assert len(entries) == 1
     assert entries[0].input_tokens == 8
-    assert entries[0].output_tokens == 7
+    assert entries[0].output_tokens == 3
     assert entries[0].cache_read_tokens == 2
 
 

--- a/tests/test_codex_loader.py
+++ b/tests/test_codex_loader.py
@@ -21,6 +21,7 @@ import codex_loader
 @pytest.fixture(autouse=True)
 def _clear_jsonl_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     codex_loader._jsonl_cache.clear()
+    codex_loader._fork_replay_cache.clear()
     monkeypatch.setattr(codex_loader, "LOGS_DB", tmp_path / "missing-logs.sqlite")
     monkeypatch.setattr(codex_loader, "STATE_DB", tmp_path / "missing-state.sqlite")
 
@@ -79,6 +80,63 @@ def _write_session_with_usage_events(
             "payload": {"type": "token_count", "info": {"total_token_usage": usage}},
         }
         for timestamp, usage in events
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+
+def _write_fork_session(
+    path: Path,
+    *,
+    session_id: str,
+    parent_session_id: str,
+    timestamp: str,
+    replay_events: list[dict[str, Any]],
+    own_events: list[tuple[str, dict[str, Any]]],
+) -> None:
+    lines = [
+        {
+            "type": "session_meta",
+            "timestamp": timestamp,
+            "payload": {
+                "id": session_id,
+                "forked_from_id": parent_session_id,
+                "timestamp": timestamp,
+                "cwd": "/tmp/fork",
+            },
+        },
+        {
+            "type": "session_meta",
+            "timestamp": timestamp,
+            "payload": {
+                "id": parent_session_id,
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "cwd": "/tmp/parent",
+            },
+        },
+    ]
+    lines.extend(
+        {
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": {"type": "token_count", "info": {"total_token_usage": usage}},
+        }
+        for usage in replay_events
+    )
+    lines.append(
+        {
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": {"type": "thread_rolled_back", "num_turns": 1},
+        }
+    )
+    lines.extend(
+        {
+            "type": "event_msg",
+            "timestamp": event_timestamp,
+            "payload": {"type": "token_count", "info": {"total_token_usage": usage}},
+        }
+        for event_timestamp, usage in own_events
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
@@ -262,6 +320,170 @@ def test_load_entries_splits_cumulative_usage_into_time_range_deltas(
     assert week_entries[0].input_tokens == 40
     assert week_entries[0].output_tokens == 20
     assert week_entries[0].cache_read_tokens == 10
+
+
+def test_load_entries_excludes_replayed_parent_usage_from_fork(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    old_ts = "2026-01-01T00:00:00+00:00"
+    fork_ts = datetime.now(UTC).replace(microsecond=0)
+    replay_ts = fork_ts.isoformat()
+    own_ts_1 = (fork_ts + timedelta(minutes=1)).isoformat()
+    own_ts_2 = (fork_ts + timedelta(minutes=2)).isoformat()
+    parent_usage = [
+        {
+            "input_tokens": 100,
+            "cached_input_tokens": 20,
+            "output_tokens": 30,
+            "reasoning_output_tokens": 10,
+        },
+        {
+            "input_tokens": 150,
+            "cached_input_tokens": 30,
+            "output_tokens": 40,
+            "reasoning_output_tokens": 15,
+        },
+    ]
+    _write_session_with_usage_events(
+        sessions_dir / "parent.jsonl",
+        session_id="parent",
+        events=[(old_ts, parent_usage[0]), (old_ts, parent_usage[1])],
+    )
+    _write_fork_session(
+        sessions_dir / "fork.jsonl",
+        session_id="fork",
+        parent_session_id="parent",
+        timestamp=replay_ts,
+        replay_events=parent_usage,
+        own_events=[
+            (
+                own_ts_1,
+                {
+                    "input_tokens": 60,
+                    "cached_input_tokens": 10,
+                    "output_tokens": 8,
+                    "reasoning_output_tokens": 3,
+                },
+            ),
+            (
+                own_ts_2,
+                {
+                    "input_tokens": 90,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 12,
+                    "reasoning_output_tokens": 5,
+                },
+            ),
+        ],
+    )
+
+    entries = codex_loader.load_entries()
+    recent_entries = codex_loader.load_entries(hours_back=24)
+
+    assert [entry.session_id for entry in entries] == ["parent", "parent", "fork", "fork"]
+    assert [entry.total_tokens for entry in entries] == [130, 60, 68, 34]
+    assert [entry.session_id for entry in recent_entries] == ["fork", "fork"]
+    assert [entry.timestamp for entry in recent_entries] == [
+        datetime.fromisoformat(own_ts_1),
+        datetime.fromisoformat(own_ts_2),
+    ]
+
+
+def test_load_entries_handles_duplicate_snapshots_across_multiple_forks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "_load_thread_models", lambda: {})
+    timestamp = datetime.now(UTC).replace(microsecond=0)
+    first_usage = {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 30}
+    second_usage = {"input_tokens": 150, "cached_input_tokens": 30, "output_tokens": 40}
+    replay = [first_usage, first_usage, second_usage]
+    _write_session_with_usage_events(
+        sessions_dir / "parent.jsonl",
+        session_id="parent",
+        events=[
+            ("2026-01-01T00:00:00+00:00", first_usage),
+            ("2026-01-01T00:01:00+00:00", first_usage),
+            ("2026-01-01T00:02:00+00:00", second_usage),
+        ],
+    )
+    for index in range(2):
+        _write_fork_session(
+            sessions_dir / f"fork-{index}.jsonl",
+            session_id=f"fork-{index}",
+            parent_session_id="parent",
+            timestamp=timestamp.isoformat(),
+            replay_events=replay,
+            own_events=[
+                (
+                    (timestamp + timedelta(minutes=index + 1)).isoformat(),
+                    {
+                        "input_tokens": 60 + index,
+                        "cached_input_tokens": 10,
+                        "output_tokens": 8,
+                    },
+                )
+            ],
+        )
+
+    entries = codex_loader.load_entries()
+
+    assert [entry.session_id for entry in entries] == [
+        "parent",
+        "parent",
+        "fork-0",
+        "fork-1",
+    ]
+    assert [entry.total_tokens for entry in entries] == [130, 60, 68, 69]
+
+
+def test_load_entries_skips_fork_jsonl_when_parent_replay_source_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    logs_db = tmp_path / "logs.sqlite"
+    monkeypatch.setattr(codex_loader, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(codex_loader, "STATE_DB", state_db)
+    monkeypatch.setattr(codex_loader, "LOGS_DB", logs_db)
+    timestamp = datetime.now(UTC).replace(microsecond=0)
+    usage = {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 30}
+    _write_fork_session(
+        sessions_dir / "fork.jsonl",
+        session_id="fork",
+        parent_session_id="missing-parent",
+        timestamp=timestamp.isoformat(),
+        replay_events=[usage],
+        own_events=[((timestamp + timedelta(minutes=1)).isoformat(), usage)],
+    )
+    sqlite_timestamp = timestamp + timedelta(minutes=2)
+    _create_state_db(state_db, [("fork", "gpt-test", "/tmp/fork")])
+    _create_logs_db(
+        logs_db,
+        [
+            (
+                1,
+                int(sqlite_timestamp.timestamp()),
+                _sqlite_token_body(
+                    session_id="fork",
+                    timestamp=sqlite_timestamp.isoformat().replace("+00:00", "Z"),
+                    input_tokens=50,
+                    output_tokens=3,
+                    cached_tokens=10,
+                ),
+            )
+        ],
+    )
+
+    entries = codex_loader.load_entries()
+
+    assert len(entries) == 1
+    assert entries[0].message_id.startswith("fork:sqlite:")
+    assert entries[0].total_tokens == 53
 
 
 def _create_state_db(path: Path, rows: list[tuple[str, str, str]]) -> None:


### PR DESCRIPTION
## Summary
- exclude timestamp-rewritten parent history embedded in Codex fork JSONL files while preserving original parent usage and post-fork deltas
- stop adding `reasoning_output_tokens` on top of output totals that already include reasoning
- make the CLI adapter aggregate the shared Codex JSONL parser so app, CLI, and reports use the same accounting

## Test plan
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m mypy .`
- [x] `.venv/bin/python -m pytest tests/test_codex_loader.py tests/test_adapters_codex.py tests/test_codex_consistency.py tests/test_analyzer_pipeline.py -q` (60 passed)
- [x] Real-data verification: today's total dropped from the false `$465.22` to `$38.74`; original parent usage and post-fork usage remain separate
- [ ] `uv run pytest tests/` (deferred to CI; local AppKit aborts when the full GUI suite runs headlessly, and two existing menubar assertions depend on local persisted preferences)

## Notes for reviewer
Codex writes a fork by embedding the parent JSONL with rewritten outer timestamps. The cumulative token sequence itself remains unchanged, so the loader matches the fork prefix against the parent source and skips only the replayed lines. If the parent source is unavailable or does not match, the JSONL is conservatively skipped and newer SQLite telemetry can still supply confirmed post-fork usage.

The replay boundary cache includes the child and parent file metadata, so it invalidates when either source changes. On the real dataset, a fresh 48-hour scan took about 1.36 seconds and a subsequent cached refresh took about 0.04 seconds.
