### PR TITLE
fix: prevent panel blank-screen from WKWebView context-menu reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 All notable changes to usage are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.22.5] - 2026-06-22
+
+### Fixed
+- **Panel no longer goes permanently blank after a context-menu "Reload"**: the popover panel loads its HTML via `loadHTMLString` with no base URL, so the WKWebView system context-menu Reload reloaded `about:blank` and left the panel blank with no obvious way to recover (#42). usage now strips navigation items (Reload/back/forward/open/download) from the panel's context menu, and internal reloads re-inject the original HTML instead of calling `reload()` — which also fixes panel recovery after the web-content process is terminated.
+
 ## [0.22.4] - 2026-06-22
 
 ### Fixed

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -4,6 +4,11 @@
 
 本檔記錄 usage 所有重要變更。格式參考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [0.22.5] - 2026-06-22
+
+### 修正
+- **面板不再因右鍵選單的「Reload」而永久空白**：彈出面板的 HTML 是以 `loadHTMLString`、不帶 base URL 的方式載入，因此 WKWebView 系統右鍵選單的 Reload 會重新載入 `about:blank`，使面板變空白且沒有明顯的恢復方式（#42）。usage 現在會從面板右鍵選單移除導航類項目（Reload／上一頁／下一頁／開啟／下載），且內部重載改為重新注入原始 HTML 而非呼叫 `reload()`——這也順帶修好面板在網頁內容程序被終止後的恢復。
+
 ## [0.22.4] - 2026-06-22
 
 ### 修正

--- a/panels/web_panel.py
+++ b/panels/web_panel.py
@@ -61,13 +61,43 @@ if TYPE_CHECKING:
 PANEL_WIDTH = 364.0
 PANEL_HEIGHT = 812.0
 MAX_INJECTION_RELOADS = 2
+NAVIGATION_MENU_IDENTIFIER_PARTS = (
+    "WKMenuItemIdentifierReload",
+    "WKMenuItemIdentifierGoBack",
+    "WKMenuItemIdentifierGoForward",
+    "WKMenuItemIdentifierOpenLink",
+    "WKMenuItemIdentifierOpenImage",
+    "WKMenuItemIdentifierOpenFrame",
+    "WKMenuItemIdentifierDownload",
+)
 
 
 def _reload_web_panel(view: Any) -> None:
     view._ready = False
     if getattr(view, "_last_payload", None) is not None:
         view._pending = view._last_payload
-    view.reload()
+    html = getattr(view, "_html", None)
+    if html is None:
+        view.reload()
+        return
+    view.loadHTMLString_baseURL_(html, None)
+
+
+def _is_navigation_menu_item(item: Any) -> bool:
+    item_identifier = getattr(item, "itemIdentifier", None)
+    if not callable(item_identifier):
+        return False
+    identifier = item_identifier()
+    if identifier is None:
+        return False
+    identifier_text = str(identifier)
+    return any(part in identifier_text for part in NAVIGATION_MENU_IDENTIFIER_PARTS)
+
+
+def _remove_navigation_menu_items(menu: Any) -> None:
+    for item in list(menu.itemArray()):
+        if _is_navigation_menu_item(item):
+            menu.removeItem_(item)
 
 
 def _handle_injection_error(view: Any, payload: dict[str, object], error: Any) -> None:
@@ -151,6 +181,7 @@ class WebPanelView(WKWebView):
     _last_payload = objc.ivar()
     _injection_retry_payload = objc.ivar()
     _injection_reload_count = objc.ivar()
+    _html = objc.ivar()
 
     def initWithFrame_configuration_delegate_(
         self,
@@ -169,6 +200,7 @@ class WebPanelView(WKWebView):
         self._last_payload = None
         self._injection_retry_payload = None
         self._injection_reload_count = 0
+        self._html = None
         self.setNavigationDelegate_(self)
         self.setValue_forKey_(False, "drawsBackground")
         self.setWantsLayer_(True)
@@ -202,6 +234,9 @@ class WebPanelView(WKWebView):
         if os.environ.get("USAGE_DEBUG") == "1":
             logger.warning("panel web content process terminated; reloading")
         _reload_web_panel(self)
+
+    def willOpenMenu_withEvent_(self, menu: Any, event: Any) -> None:
+        _remove_navigation_menu_items(menu)
 
     def renderTimeoutElapsed_(self, _arg: Any) -> None:
         # If the HTML never finished rendering, the popover shows only the dark
@@ -239,6 +274,7 @@ class WebPanelView(WKWebView):
         self.user_content_controller = None
         self._last_payload = None
         self._pending = None
+        self._html = None
 
 
 class ErrorPanelView(NSView):
@@ -320,6 +356,7 @@ class HTMLPanel:
             bridge = UsageScriptBridge.alloc().initWithDelegate_webView_(delegate, web_view)
             web_view.setBridge_(bridge)
             controller.addScriptMessageHandler_name_(bridge, "usage")
+            web_view._html = html
             web_view.loadHTMLString_baseURL_(html, None)
             web_view.performSelector_withObject_afterDelay_("renderTimeoutElapsed:", None, 4.0)
             return web_view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usage"
-version = "0.22.4"
+version = "0.22.5"
 description = "usage — 在 macOS menu bar 顯示 Claude Code 用量的繁中小工具（也提供終端機 TUI）"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -192,6 +192,42 @@ def test_evaluate_javascript_completion_handler_block_signature() -> None:
     view.evaluateJavaScript_completionHandler_("1+1", lambda value, error: None)
 
 
+def test_web_panel_context_menu_removes_navigation_items() -> None:
+    import panels.web_panel as web_panel
+
+    class FakeMenuItem:
+        def __init__(self, identifier: str | None) -> None:
+            self.identifier = identifier
+
+        def itemIdentifier(self) -> str | None:
+            return self.identifier
+
+    class FakeMenu:
+        def __init__(self) -> None:
+            self.reload = FakeMenuItem("WKMenuItemIdentifierReload")
+            self.copy = FakeMenuItem("WKMenuItemIdentifierCopy")
+            self.open_link = FakeMenuItem("WKMenuItemIdentifierOpenLinkInNewWindow")
+            self.no_identifier = FakeMenuItem(None)
+            self.items = [
+                self.reload,
+                self.copy,
+                self.open_link,
+                self.no_identifier,
+            ]
+
+        def itemArray(self) -> list[FakeMenuItem]:
+            return self.items
+
+        def removeItem_(self, item: FakeMenuItem) -> None:
+            self.items.remove(item)
+
+    menu = FakeMenu()
+
+    web_panel._remove_navigation_menu_items(menu)
+
+    assert menu.items == [menu.copy, menu.no_identifier]
+
+
 def test_build_view_falls_back_to_error_panel_on_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -233,10 +269,15 @@ def test_web_panel_reloads_and_reinjects_after_content_termination() -> None:
             self._ready = True
             self._pending = None
             self._last_payload = {"codex": {"session": {"percent": 67}}}
+            self._html = "<html>usage</html>"
             self.reloads = 0
+            self.loaded_html: list[tuple[str, object | None]] = []
 
         def reload(self) -> None:
             self.reloads += 1
+
+        def loadHTMLString_baseURL_(self, html: str, base_url: object | None) -> None:
+            self.loaded_html.append((html, base_url))
 
     view = FakeWebView()
 
@@ -244,7 +285,8 @@ def test_web_panel_reloads_and_reinjects_after_content_termination() -> None:
 
     assert view._ready is False
     assert view._pending == {"codex": {"session": {"percent": 67}}}
-    assert view.reloads == 1
+    assert view.loaded_html == [("<html>usage</html>", None)]
+    assert view.reloads == 0
 
 
 def test_web_panel_reloads_when_state_injection_fails() -> None:
@@ -255,10 +297,15 @@ def test_web_panel_reloads_when_state_injection_fails() -> None:
             self._ready = True
             self._pending = None
             self._last_payload = None
+            self._html = "<html>usage</html>"
             self.reloads = 0
+            self.loaded_html: list[tuple[str, object | None]] = []
 
         def reload(self) -> None:
             self.reloads += 1
+
+        def loadHTMLString_baseURL_(self, html: str, base_url: object | None) -> None:
+            self.loaded_html.append((html, base_url))
 
     view = FakeWebView()
     payload: dict[str, object] = {"projects": [{"name": "Eric-Tools"}]}
@@ -267,7 +314,8 @@ def test_web_panel_reloads_when_state_injection_fails() -> None:
 
     assert view._ready is False
     assert view._pending == payload
-    assert view.reloads == 1
+    assert view.loaded_html == [("<html>usage</html>", None)]
+    assert view.reloads == 0
 
 
 def test_web_panel_caps_reloads_when_state_injection_keeps_failing() -> None:
@@ -280,10 +328,15 @@ def test_web_panel_caps_reloads_when_state_injection_keeps_failing() -> None:
             self._last_payload = None
             self._injection_retry_payload = None
             self._injection_reload_count = 0
+            self._html = "<html>usage</html>"
             self.reloads = 0
+            self.loaded_html: list[tuple[str, object | None]] = []
 
         def reload(self) -> None:
             self.reloads += 1
+
+        def loadHTMLString_baseURL_(self, html: str, base_url: object | None) -> None:
+            self.loaded_html.append((html, base_url))
 
     view = FakeWebView()
     payload: dict[str, object] = {"projects": [{"name": "Eric-Tools"}]}
@@ -291,9 +344,41 @@ def test_web_panel_caps_reloads_when_state_injection_keeps_failing() -> None:
     for _ in range(web_panel.MAX_INJECTION_RELOADS + 3):
         web_panel._handle_injection_error(view, payload, "boom")
 
-    assert view.reloads == web_panel.MAX_INJECTION_RELOADS
+    assert view.loaded_html == [
+        ("<html>usage</html>", None),
+        ("<html>usage</html>", None),
+    ]
+    assert view.reloads == 0
     assert view._pending is None
 
     web_panel._reload_web_panel(view)
 
-    assert view.reloads == web_panel.MAX_INJECTION_RELOADS + 1
+    assert view.loaded_html == [
+        ("<html>usage</html>", None),
+        ("<html>usage</html>", None),
+        ("<html>usage</html>", None),
+    ]
+    assert view.reloads == 0
+
+
+def test_web_panel_reload_falls_back_to_reload_without_html() -> None:
+    import panels.web_panel as web_panel
+
+    class FakeWebView:
+        def __init__(self) -> None:
+            self._ready = True
+            self._pending = None
+            self._last_payload = None
+            self._html = None
+            self.reloads = 0
+
+        def reload(self) -> None:
+            self.reloads += 1
+
+    view = FakeWebView()
+
+    web_panel._reload_web_panel(view)
+
+    assert view._ready is False
+    assert view._pending is None
+    assert view.reloads == 1


### PR DESCRIPTION
## What

Fixes the panel going permanently blank after a right-click "Reload".

Closes #42

## Root cause

The popover panel loads its HTML via `loadHTMLString` with **no base URL**, so the WKWebView system context-menu **Reload** reloads `about:blank` — the panel goes blank and there is no obvious way to recover. The same dead path also broke `webViewWebContentProcessDidTerminate_` recovery, which likewise called `view.reload()`.

## Fix (`panels/web_panel.py`, `tests/test_panels.py`)

- `willOpenMenu:withEvent:` strips navigation context-menu items (Reload / back / forward / open-in-new-window / download), keeping text operations like Copy.
- The original HTML is stashed on `web_view._html`; `_reload_web_panel` now re-injects it via `loadHTMLString_baseURL_(html, None)` instead of `reload()`, falling back to `reload()` when `_html is None`. This also makes web-content-process-termination recovery actually restore the panel.

## Verification

`uv run ruff check`, `uv run mypy .`, `uv run pytest -v` (654 passed) all green. New tests cover the menu filtering, the loadHTMLString reload path, and the `_html is None` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)