### PR TITLE
fix: refresh pricing when new models appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 All notable changes to usage are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+- **New model pricing refreshes as soon as usage sees an unknown model**: fresh cached pricing could hide newly-added models until the 7-day TTL expired, temporarily rendering them as $0.00/unknown. A pricing miss now triggers a debounced background refresh, and Claude Sonnet 5 has an offline fallback price so first-run or offline usage still estimates cost.
+
 ## [0.22.11] - 2026-06-27
 
 ### Fixed

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -4,6 +4,11 @@
 
 本檔記錄 usage 所有重要變更。格式參考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## Unreleased
+
+### 修正
+- **看到未知模型時會立即背景更新價格表**：新模型剛上線時，即使上游價格表已更新，本機 7 天快取仍可能讓模型暫時顯示為 $0.00／未知；現在模型價格 miss 會觸發帶 debounce 的背景刷新，並補上 Claude Sonnet 5 的離線 fallback 價格，讓首次啟動或離線狀態仍能估算成本。
+
 ## [0.22.11] - 2026-06-27
 
 ### 修正

--- a/pricing.py
+++ b/pricing.py
@@ -30,6 +30,7 @@ CACHE_PATH = DEFAULT_CACHE_PATH
 LEGACY_CACHE_PATH = DEFAULT_LEGACY_CACHE_PATH
 CACHE_TTL_DAYS = 7
 FALLBACK_RETRY_SECONDS = 600
+MISSING_MODEL_REFRESH_SECONDS = FALLBACK_RETRY_SECONDS
 USER_AGENT = "usage/0.9"
 PROVIDER_PREFIXES = (
     "openai/",
@@ -48,6 +49,8 @@ PricingSource = Literal["cache", "stale", "fetched", "fallback"]
 _pricing_cache: tuple[PricingTable, PricingSource, float] | None = None
 _pricing_cache_lock = threading.Lock()
 _pricing_warm_up_in_progress = False
+_pricing_miss_refresh_at: float | None = None
+_pricing_miss_refresh_lock = threading.Lock()
 
 
 class _CostEntry(Protocol):
@@ -66,6 +69,7 @@ def calculate_cost(entry: _CostEntry) -> float:
     pricing = get_pricing()
     model_key = _resolve_model_key(entry.model, pricing)
     if model_key is None:
+        _request_pricing_refresh_for_missing_model()
         return 0.0
 
     model_pricing = pricing[model_key]
@@ -89,7 +93,11 @@ def calculate_cost(entry: _CostEntry) -> float:
 def is_model_priced(model: str) -> bool:
     """Check if a model has pricing information available."""
     pricing = get_pricing()
-    return _resolve_model_key(model, pricing) is not None
+    model_key = _resolve_model_key(model, pricing)
+    if model_key is None:
+        _request_pricing_refresh_for_missing_model()
+        return False
+    return True
 
 
 def get_pricing() -> PricingTable:
@@ -176,9 +184,11 @@ def _get_pricing_cache_for_test() -> tuple[PricingTable, PricingSource, float] |
 
 
 def _reset_pricing_warm_up_for_test() -> None:
-    global _pricing_warm_up_in_progress
+    global _pricing_warm_up_in_progress, _pricing_miss_refresh_at
     with _pricing_cache_lock:
         _pricing_warm_up_in_progress = False
+    with _pricing_miss_refresh_lock:
+        _pricing_miss_refresh_at = None
 
 
 def _load_pricing() -> PricingTable:
@@ -326,6 +336,12 @@ def _fallback_pricing() -> PricingTable:
             "cache_creation_input_token_cost": 3.75e-6,
             "cache_read_input_token_cost": 0.3e-6,
         },
+        "claude-sonnet-5": {
+            "input_cost_per_token": 2e-6,
+            "output_cost_per_token": 10e-6,
+            "cache_creation_input_token_cost": 2.5e-6,
+            "cache_read_input_token_cost": 0.2e-6,
+        },
         "claude-haiku-4-5-20251001": {
             "input_cost_per_token": 0.8e-6,
             "output_cost_per_token": 4e-6,
@@ -333,3 +349,16 @@ def _fallback_pricing() -> PricingTable:
             "cache_read_input_token_cost": 0.08e-6,
         },
     }
+
+
+def _request_pricing_refresh_for_missing_model() -> None:
+    global _pricing_miss_refresh_at
+    now = time.monotonic()
+    with _pricing_miss_refresh_lock:
+        if (
+            _pricing_miss_refresh_at is not None
+            and (now - _pricing_miss_refresh_at) < MISSING_MODEL_REFRESH_SECONDS
+        ):
+            return
+        _pricing_miss_refresh_at = now
+    warm_up_pricing()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -78,8 +78,49 @@ def test_calculate_cost_returns_zero_for_unknown_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(pricing, "get_pricing", lambda: {"known": {"input_cost_per_token": 1.0}})
+    monkeypatch.setattr(pricing, "warm_up_pricing", lambda on_ready=None: None)
 
     assert pricing.calculate_cost(_entry(model="missing", input_tokens=100)) == 0.0
+
+
+def test_calculate_cost_triggers_pricing_refresh_for_unknown_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warm_up_calls = 0
+
+    def fake_warm_up_pricing(on_ready: object = None) -> None:
+        nonlocal warm_up_calls
+        _ = on_ready
+        warm_up_calls += 1
+
+    monkeypatch.setattr(pricing, "get_pricing", lambda: {"known": {"input_cost_per_token": 1.0}})
+    monkeypatch.setattr(pricing, "warm_up_pricing", fake_warm_up_pricing)
+    monkeypatch.setattr("pricing.time.monotonic", lambda: 1.0)
+
+    assert pricing.calculate_cost(_entry(model="missing", input_tokens=100)) == 0.0
+    assert warm_up_calls == 1
+
+
+def test_unknown_model_pricing_refresh_is_debounced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warm_up_calls = 0
+    now = 1_000.0
+
+    def fake_warm_up_pricing(on_ready: object = None) -> None:
+        nonlocal warm_up_calls
+        _ = on_ready
+        warm_up_calls += 1
+
+    monkeypatch.setattr(pricing, "get_pricing", lambda: {"known": {"input_cost_per_token": 1.0}})
+    monkeypatch.setattr(pricing, "warm_up_pricing", fake_warm_up_pricing)
+    monkeypatch.setattr("pricing.time.monotonic", lambda: now)
+
+    assert pricing.calculate_cost(_entry(model="missing", input_tokens=100)) == 0.0
+    assert pricing.calculate_cost(_entry(model="missing", input_tokens=100)) == 0.0
+    now += pricing.FALLBACK_RETRY_SECONDS + 1
+    assert pricing.calculate_cost(_entry(model="missing", input_tokens=100)) == 0.0
+    assert warm_up_calls == 2
 
 
 def test_calculate_cost_sums_all_token_types(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -238,6 +279,7 @@ def test_fallback_pricing_contains_expected_models() -> None:
 
     assert "claude-opus-4-7" in fallback
     assert "claude-sonnet-4-6" in fallback
+    assert "claude-sonnet-5" in fallback
     assert "claude-haiku-4-5-20251001" in fallback
     assert fallback["claude-opus-4-6"] == {
         "input_cost_per_token": 15e-6,
@@ -250,6 +292,12 @@ def test_fallback_pricing_contains_expected_models() -> None:
         "output_cost_per_token": 75e-6,
         "cache_creation_input_token_cost": 18.75e-6,
         "cache_read_input_token_cost": 1.5e-6,
+    }
+    assert fallback["claude-sonnet-5"] == {
+        "input_cost_per_token": 2e-6,
+        "output_cost_per_token": 10e-6,
+        "cache_creation_input_token_cost": 2.5e-6,
+        "cache_read_input_token_cost": 0.2e-6,
     }
 
 
@@ -708,6 +756,7 @@ def test_is_model_priced_returns_false_for_unknown_model(
         "claude-opus-4-8": {"input_cost_per_token": 15e-6},
     }
     pricing._set_pricing_cache_for_test((pricing_table, "cache", 0.0))
+    monkeypatch.setattr(pricing, "warm_up_pricing", lambda on_ready=None: None)
 
     assert pricing.is_model_priced("glm-5.2") is False
     assert pricing.is_model_priced("unknown-model") is False


### PR DESCRIPTION
## Summary
- trigger a debounced background pricing refresh when usage sees a model that is missing from the current pricing table
- add a Claude Sonnet 5 fallback price so offline or first-run cost estimates do not temporarily render as zero while the cache is stale
- cover the miss-trigger and debounce behavior in pricing tests

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_pricing.py -q` (41 passed)
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m mypy .`
- [x] `git diff --check`
- [x] Local smoke check: `claude-sonnet-5` fallback computes a non-zero estimate
- [ ] `.venv/bin/python -m pytest -q` (local-only failure: 5 existing Codex adapter tests read real `~/.codex` archived session data despite their temp session monkeypatch; 672 passed)

## Notes for reviewer
The root cause was that a fresh 7-day pricing cache could still be missing a newly-added model, so `calculate_cost()` returned `0.0` until the cache TTL expired. The new miss-trigger keeps the existing fast cached path, but asks the background refresher to update pricing after an unknown model appears. A monotonic backoff prevents repeated report/menu refreshes from starting a network fetch loop.

Claude Code 2.1.197 is already writing `claude-sonnet-5` in local logs/status files, and LiteLLM's upstream pricing JSON already contains `claude-sonnet-5`; this change closes the stale-cache gap between those two facts.
