### PR TITLE
Fix Windows support: tray startup, test suite, and mypy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Run ruff
         run: uv run ruff check .
 
-      # PyObjC stubs and Darwin-only dependency markers leave Windows without
-      # a complete type environment; keep mypy on the existing macOS job.
+      - name: Run mypy
+        run: uv run mypy .
+
       - name: Run pytest
         run: uv run pytest -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Changed
+- **mypy now runs on the Windows CI job too**: the `check-windows` job previously skipped type checking, which is how several Windows-only defects (including the tray-startup crash surface) went unnoticed. The platform-conditional code paths (`termios`/`msvcrt` key readers, `os.getuid`, `time.tzset`, pywebview's `Window | None`) are now typed so that `mypy .` is clean on both macOS and Windows.
+
 ### Fixed
 - **The Windows tray now actually starts**: importing the tray pulled in the `panels` package, whose `__init__` eagerly imported the PyObjC-backed `panels.web_panel`; on Windows this raised `ModuleNotFoundError: No module named 'objc'`, and because the TUI fallback in `main.py` only recognized a missing `wintray` module, the windowed build exited silently with nothing on screen. The panel registry now imports `web_panel` lazily inside `all_panels()` (macOS behavior unchanged), and the fallback degrades to the TUI whenever any module in the tray's import chain is missing, printing the missing module's name.
 - **The tray menu and JS bridge no longer break at startup**: pystray rejects menu actions whose lambda carries an extra defaulted positional parameter, so building the panel-switch submenu raised `ValueError` before the icon ever appeared; and pywebview serializes every public attribute of the `js_api` object into the JS bridge, so exposing the tray controller on it recursed through the WinForms window graph until the recursion limit. The panel-id binding is now keyword-only, and the bridge holds the controller in a private attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 All notable changes to usage are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+- **The Windows tray now actually starts**: importing the tray pulled in the `panels` package, whose `__init__` eagerly imported the PyObjC-backed `panels.web_panel`; on Windows this raised `ModuleNotFoundError: No module named 'objc'`, and because the TUI fallback in `main.py` only recognized a missing `wintray` module, the windowed build exited silently with nothing on screen. The panel registry now imports `web_panel` lazily inside `all_panels()` (macOS behavior unchanged), and the fallback degrades to the TUI whenever any module in the tray's import chain is missing, printing the missing module's name.
+- **The tray menu and JS bridge no longer break at startup**: pystray rejects menu actions whose lambda carries an extra defaulted positional parameter, so building the panel-switch submenu raised `ValueError` before the icon ever appeared; and pywebview serializes every public attribute of the `js_api` object into the JS bridge, so exposing the tray controller on it recursed through the WinForms window graph until the recursion limit. The panel-id binding is now keyword-only, and the bridge holds the controller in a private attribute.
+- **Project names derive correctly from POSIX-style cwds on Windows**: `usage_session_resume._project_from_cwd` and `adapters.claude.project_from_cwd` split paths on `os.sep` only, so a transcript cwd recorded with forward slashes (or a `C:/...`-style path) kept the whole path as the "project" on Windows. Both now normalize separators on Windows before splitting; POSIX behavior is unchanged, since backslashes are legal in POSIX filenames.
+- **The test suite collects and passes on Windows**: the `check-windows` CI job had been red since it was introduced. Five test modules that import PyObjC-backed code at module level are now skipped outside macOS via `collect_ignore`; timezone pinning that relied on `TZ` + `time.tzset()` (unavailable on Windows) now pins the conversion points directly; setup-hook tests no longer hardcode `/usr/bin/python3` or `/bin/sh`; and the Codex adapter/consistency tests now sandbox `ARCHIVED_SESSIONS_DIR` and the JSONL disk cache, which previously leaked real `~/.codex` history on any machine with usage data — regardless of OS.
+
 ## [0.28.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+### 變更
+- **mypy 現在也會在 Windows CI job 上執行**：`check-windows` job 過去跳過型別檢查，這正是數個 Windows 限定缺陷（包括系統匣啟動崩潰面）沒被發現的原因。平台條件式的程式碼路徑（`termios`／`msvcrt` 按鍵讀取、`os.getuid`、`time.tzset`、pywebview 的 `Window | None`）現在都有正確型別，讓 `mypy .` 在 macOS 與 Windows 上都乾淨通過。
+
 ### 修正
 - **Windows 系統匣現在真的能啟動了**：載入系統匣會一併載入 `panels` 套件，而其 `__init__` 會立刻 import 依賴 PyObjC 的 `panels.web_panel`；在 Windows 上這會拋出 `ModuleNotFoundError: No module named 'objc'`，且 `main.py` 的 TUI 後備機制只認得 `wintray` 模組本身缺失的情況，導致視窗版建置無聲無息地結束、畫面上什麼都不會出現。面板註冊表現在改為在 `all_panels()` 內惰性 import `web_panel`（macOS 行為不變），且只要系統匣 import 鏈中任一模組缺失，後備機制都會退回 TUI 並印出缺失模組的名稱。
 - **系統匣選單與 JS 橋接不再於啟動時故障**：pystray 會拒絕 lambda 帶有額外預設位置參數的選單動作，因此建立面板切換子選單時會在圖示出現前就拋出 `ValueError`；而 pywebview 會把 `js_api` 物件的所有公開屬性序列化進 JS 橋接，因此把系統匣 controller 掛在上面會沿著 WinForms 視窗物件圖無限遞迴直到達到遞迴上限。面板 id 綁定現在改為 keyword-only，橋接物件也改用私有屬性持有 controller。

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -4,6 +4,14 @@
 
 本檔記錄 usage 所有重要變更。格式參考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## Unreleased
+
+### 修正
+- **Windows 系統匣現在真的能啟動了**：載入系統匣會一併載入 `panels` 套件，而其 `__init__` 會立刻 import 依賴 PyObjC 的 `panels.web_panel`；在 Windows 上這會拋出 `ModuleNotFoundError: No module named 'objc'`，且 `main.py` 的 TUI 後備機制只認得 `wintray` 模組本身缺失的情況，導致視窗版建置無聲無息地結束、畫面上什麼都不會出現。面板註冊表現在改為在 `all_panels()` 內惰性 import `web_panel`（macOS 行為不變），且只要系統匣 import 鏈中任一模組缺失，後備機制都會退回 TUI 並印出缺失模組的名稱。
+- **系統匣選單與 JS 橋接不再於啟動時故障**：pystray 會拒絕 lambda 帶有額外預設位置參數的選單動作，因此建立面板切換子選單時會在圖示出現前就拋出 `ValueError`；而 pywebview 會把 `js_api` 物件的所有公開屬性序列化進 JS 橋接，因此把系統匣 controller 掛在上面會沿著 WinForms 視窗物件圖無限遞迴直到達到遞迴上限。面板 id 綁定現在改為 keyword-only，橋接物件也改用私有屬性持有 controller。
+- **Windows 上能正確從 POSIX 風格的 cwd 取出專案名稱**：`usage_session_resume._project_from_cwd` 與 `adapters.claude.project_from_cwd` 過去只用 `os.sep` 切割路徑，因此在 Windows 上讀到以正斜線記錄的 transcript cwd（或 `C:/...` 風格路徑）時，會把整條路徑當成「專案名稱」。兩處現在都會在 Windows 上先統一分隔符再切割；POSIX 行為不變，因為反斜線在 POSIX 檔名中是合法字元。
+- **測試套件在 Windows 上可收集、可通過**：`check-windows` CI job 自新增以來一直是紅的。五個在模組層級 import PyObjC 相關程式碼的測試模組，現在透過 `collect_ignore` 在非 macOS 平台跳過；原本依賴 `TZ` + `time.tzset()`（Windows 沒有）的時區釘選改為直接釘住換算點；setup-hook 測試不再寫死 `/usr/bin/python3` 與 `/bin/sh`；Codex adapter／一致性測試現在會隔離 `ARCHIVED_SESSIONS_DIR` 與 JSONL 磁碟快取——先前不分作業系統，只要機器上有使用紀錄，就會把真實的 `~/.codex` 歷史洩漏進斷言。
+
 ## [0.28.0] - 2026-07-15
 
 ### 新增

--- a/adapters/claude.py
+++ b/adapters/claude.py
@@ -69,11 +69,17 @@ def get_claude_dirs() -> list[str]:
 
 def project_from_cwd(cwd: str) -> str:
     home = os.path.expanduser("~")
-    if cwd.startswith(home):
-        rel = cwd[len(home):].strip(os.sep)
+    rel = cwd[len(home):] if cwd.startswith(home) else cwd
+    # Windows sessions read transcripts whose cwd may use either separator
+    # (e.g. POSIX-style paths). POSIX filenames may legitimately contain
+    # backslashes, so only normalize them on Windows.
+    if sys.platform == "win32":
+        rel = rel.replace("\\", "/")
+        sep = "/"
     else:
-        rel = cwd.strip(os.sep)
-    parts = rel.split(os.sep)
+        sep = os.sep
+    rel = rel.strip(sep)
+    parts = rel.split(sep)
     return parts[-1] if parts and parts[-1] else rel or "unknown"
 
 

--- a/login_item.py
+++ b/login_item.py
@@ -80,6 +80,10 @@ def _write_plist(contents: str) -> None:
 
 
 def _launchctl_domain_target() -> str:
+    # login_item is only imported on macOS; the guard also keeps mypy's win32
+    # run (which has no os.getuid) off the POSIX call.
+    if sys.platform == "win32":
+        raise RuntimeError("login_item is macOS-only")
     return f"gui/{os.getuid()}"
 
 

--- a/main.py
+++ b/main.py
@@ -331,9 +331,10 @@ def main() -> None:
         try:
             wintray = importlib.import_module("wintray")
         except ModuleNotFoundError as exc:
-            if exc.name != "wintray":
-                raise
-            print(_t("wintray_unavailable"))
+            # Any missing module — wintray itself, an optional GUI package, or a
+            # transitive import — must degrade to the TUI; a bare raise would exit
+            # a --windowed build with no visible output at all.
+            print(f"{_t('wintray_unavailable')} [{exc.name}]")
             with suppress(KeyboardInterrupt):
                 asyncio.run(
                     run_tui(mock=args.mock, interval=args.interval, force_group=args.force_group)
@@ -342,9 +343,7 @@ def main() -> None:
             try:
                 wintray.run_app(mock=args.mock, interval=args.interval)
             except ModuleNotFoundError as exc:
-                if exc.name not in {"pystray", "PIL", "webview"}:
-                    raise
-                print(_t("wintray_unavailable"))
+                print(f"{_t('wintray_unavailable')} [{exc.name}]")
                 with suppress(KeyboardInterrupt):
                     asyncio.run(
                         run_tui(

--- a/panels/__init__.py
+++ b/panels/__init__.py
@@ -6,121 +6,126 @@
 
 from __future__ import annotations
 
+from functools import cache
+
 from panels.base import Panel
-from panels.web_panel import HTMLPanel
-
-# claude_card_height mirrors codex_card_height: the two cards share the same
-# structure (header + two quota rows) and measure equal in headless renders.
-PANELS: tuple[Panel, ...] = (
-    HTMLPanel(
-        "classic",
-        "panel_default_name",
-        "classic.html",
-        height=1004.0,
-        claude_card_height=192.0,
-        codex_card_height=192.0,
-        agy_card_height=192.0,
-    ),
-    HTMLPanel(
-        "matrix",
-        "panel_matrix",
-        "matrix.html",
-        height=1070.0,
-        claude_card_height=200.0,
-        codex_card_height=200.0,
-        agy_card_height=200.0,
-    ),
-    HTMLPanel(
-        "win95",
-        "panel_win95",
-        "win95.html",
-        height=1079.0,
-        claude_card_height=210.0,
-        codex_card_height=209.0,
-        agy_card_height=209.0,
-    ),
-    HTMLPanel(
-        "newspaper",
-        "panel_newspaper",
-        "newspaper.html",
-        height=1073.0,
-        claude_card_height=205.0,
-        codex_card_height=203.0,
-        agy_card_height=203.0,
-    ),
-    HTMLPanel(
-        "cloud_observation",
-        "panel_cloud_observation",
-        "cloud_observation.html",
-        height=1023.0,
-        claude_card_height=211.0,
-        codex_card_height=211.0,
-        agy_card_height=211.0,
-    ),
-    HTMLPanel(
-        "aquarium",
-        "panel_aquarium",
-        "aquarium.html",
-        height=1023.0,
-        claude_card_height=211.0,
-        codex_card_height=211.0,
-        agy_card_height=211.0,
-    ),
-    HTMLPanel(
-        "prism_arcade",
-        "panel_prism_arcade",
-        "prism_arcade.html",
-        height=1023.0,
-        claude_card_height=211.0,
-        codex_card_height=211.0,
-        agy_card_height=211.0,
-    ),
-    HTMLPanel(
-        "black_hole",
-        "panel_black_hole",
-        "black_hole.html",
-        height=1023.0,
-        claude_card_height=211.0,
-        codex_card_height=211.0,
-        agy_card_height=211.0,
-    ),
-    HTMLPanel(
-        "lepidoptera",
-        "panel_lepidoptera",
-        "lepidoptera.html",
-        height=1070.0,
-        claude_card_height=208.0,
-        codex_card_height=208.0,
-        agy_card_height=208.0,
-    ),
-    HTMLPanel(
-        "world_cup",
-        "panel_world_cup",
-        "world_cup.html",
-        claude_card_height=0.0,
-        codex_card_height=0.0,
-    ),
-    HTMLPanel(
-        "talent_market",
-        "panel_talent_market",
-        "talent_market.html",
-        height=812.0,
-        claude_card_height=0.0,
-        codex_card_height=0.0,
-    ),
-)
 
 
+@cache
 def all_panels() -> tuple[Panel, ...]:
-    return PANELS
+    # web_panel requires PyObjC at import time (objc/AppKit/WebKit), which only
+    # exists on macOS. Import it lazily so importing the panels package (e.g.
+    # wintray -> panels.payload on Windows) never pulls it in.
+    from panels.web_panel import HTMLPanel
+
+    # claude_card_height mirrors codex_card_height: the two cards share the same
+    # structure (header + two quota rows) and measure equal in headless renders.
+    return (
+        HTMLPanel(
+            "classic",
+            "panel_default_name",
+            "classic.html",
+            height=1004.0,
+            claude_card_height=192.0,
+            codex_card_height=192.0,
+            agy_card_height=192.0,
+        ),
+        HTMLPanel(
+            "matrix",
+            "panel_matrix",
+            "matrix.html",
+            height=1070.0,
+            claude_card_height=200.0,
+            codex_card_height=200.0,
+            agy_card_height=200.0,
+        ),
+        HTMLPanel(
+            "win95",
+            "panel_win95",
+            "win95.html",
+            height=1079.0,
+            claude_card_height=210.0,
+            codex_card_height=209.0,
+            agy_card_height=209.0,
+        ),
+        HTMLPanel(
+            "newspaper",
+            "panel_newspaper",
+            "newspaper.html",
+            height=1073.0,
+            claude_card_height=205.0,
+            codex_card_height=203.0,
+            agy_card_height=203.0,
+        ),
+        HTMLPanel(
+            "cloud_observation",
+            "panel_cloud_observation",
+            "cloud_observation.html",
+            height=1023.0,
+            claude_card_height=211.0,
+            codex_card_height=211.0,
+            agy_card_height=211.0,
+        ),
+        HTMLPanel(
+            "aquarium",
+            "panel_aquarium",
+            "aquarium.html",
+            height=1023.0,
+            claude_card_height=211.0,
+            codex_card_height=211.0,
+            agy_card_height=211.0,
+        ),
+        HTMLPanel(
+            "prism_arcade",
+            "panel_prism_arcade",
+            "prism_arcade.html",
+            height=1023.0,
+            claude_card_height=211.0,
+            codex_card_height=211.0,
+            agy_card_height=211.0,
+        ),
+        HTMLPanel(
+            "black_hole",
+            "panel_black_hole",
+            "black_hole.html",
+            height=1023.0,
+            claude_card_height=211.0,
+            codex_card_height=211.0,
+            agy_card_height=211.0,
+        ),
+        HTMLPanel(
+            "lepidoptera",
+            "panel_lepidoptera",
+            "lepidoptera.html",
+            height=1070.0,
+            claude_card_height=208.0,
+            codex_card_height=208.0,
+            agy_card_height=208.0,
+        ),
+        HTMLPanel(
+            "world_cup",
+            "panel_world_cup",
+            "world_cup.html",
+            claude_card_height=0.0,
+            codex_card_height=0.0,
+        ),
+        HTMLPanel(
+            "talent_market",
+            "panel_talent_market",
+            "talent_market.html",
+            height=812.0,
+            claude_card_height=0.0,
+            codex_card_height=0.0,
+        ),
+    )
 
 
 def panel_ids() -> tuple[str, ...]:
-    return tuple(panel.id for panel in PANELS)
+    return tuple(panel.id for panel in all_panels())
 
 
 def get_panel(panel_id: str) -> Panel:
-    for panel in PANELS:
+    for panel in all_panels():
         if panel.id == panel_id:
             return panel
-    return PANELS[0]
+    return all_panels()[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,14 @@ ignore_missing_imports = true
 module = ["AppKit", "Foundation", "objc", "Quartz", "UserNotifications", "WebKit"]
 ignore_missing_imports = true
 
+# usage_cli's key readers pair a POSIX branch (termios/tty) with a Windows
+# branch (msvcrt); each side's `type: ignore` comments are only "used" when
+# mypy runs on the other platform, so unused-ignore warnings must stay off
+# for this module to keep `mypy .` green on both macOS and Windows CI.
+[[tool.mypy.overrides]]
+module = "usage_cli"
+warn_unused_ignores = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra --strict-markers"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,20 @@ from tests.helpers import ResumeHookPaths, SetupHookPaths, TerseHookPaths
 from tests.helpers import patch_resume_hook_paths as _patch_resume_hook_paths
 from tests.helpers import patch_setup_hook_paths as _patch_setup_hook_paths
 from tests.helpers import patch_terse_hook_paths as _patch_terse_hook_paths
+
+# These modules import PyObjC-backed code (menubar, login_item, panels.web_panel)
+# at module level, so they can only be collected on macOS.
+collect_ignore = (
+    []
+    if sys.platform == "darwin"
+    else [
+        "test_analyzer_pipeline.py",
+        "test_login_item.py",
+        "test_menubar.py",
+        "test_panels.py",
+        "test_web_panel_payload.py",
+    ]
+)
 
 
 @pytest.fixture

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,6 +13,14 @@ import session_hooks
 import setup_hook
 
 
+def expected_statusline_command(target: Path) -> str:
+    # setup() writes the command through _find_system_python + _shell_arg;
+    # mirror that here so assertions hold on POSIX (where the fixture mocks
+    # shutil.which to /usr/bin/python3) and on Windows (sys.executable).
+    python = setup_hook._find_system_python()
+    return f"{setup_hook._shell_arg(python)} {setup_hook._shell_arg(str(target))}"
+
+
 def write_codex_session(
     path: Path,
     *,

--- a/tests/test_adapters_codex.py
+++ b/tests/test_adapters_codex.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+import codex_loader
 from adapters import codex
 from tests.helpers import write_codex_session as _write_session
 from tests.helpers import (
@@ -19,8 +20,19 @@ from tests.helpers import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_file_cache() -> None:
+def _clear_file_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     codex._file_cache.clear()
+    # Keep the loader away from the developer's real ~/.codex and ~/.usage:
+    # the archived-sessions dir and the JSONL disk cache would otherwise leak
+    # real entries into assertions on machines with usage history.
+    monkeypatch.setattr(
+        codex_loader, "ARCHIVED_SESSIONS_DIR", tmp_path / "archived_sessions"
+    )
+    monkeypatch.setattr(
+        codex_loader, "JSONL_CACHE_PATH", tmp_path / "codex_jsonl_cache.json"
+    )
+    monkeypatch.setattr(codex_loader, "_disk_cache_seeded", True)
+    codex_loader._jsonl_cache.clear()
 
 
 def test_loaders_skip_bad_utf8_jsonl_without_crashing(

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -16,13 +16,19 @@ from adapters.types import UsageEntry
 from analyzer.aggregator import aggregate_daily
 
 
+def _tzset() -> None:
+    # The test is skipif-gated on tzset, but calling time.tzset() directly
+    # fails mypy's win32 run, where the attribute does not exist.
+    getattr(time, "tzset", lambda: None)()
+
+
 @pytest.mark.skipif(not hasattr(time, "tzset"), reason="tzset unavailable")
 def test_aggregate_daily_groups_entries_by_local_date(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     original_tz = os.environ.get("TZ")
     monkeypatch.setenv("TZ", "Asia/Taipei")
-    time.tzset()
+    _tzset()
     try:
         entries = [
             UsageEntry(
@@ -61,7 +67,7 @@ def test_aggregate_daily_groups_entries_by_local_date(
             monkeypatch.delenv("TZ", raising=False)
         else:
             monkeypatch.setenv("TZ", original_tz)
-        time.tzset()
+        _tzset()
 
     assert len(daily) == 1
     assert daily[0].date == "2026-06-27"

--- a/tests/test_codex_consistency.py
+++ b/tests/test_codex_consistency.py
@@ -19,9 +19,19 @@ FIXTURE = Path(__file__).parent / "fixtures" / "codex_session_golden.jsonl"
 
 
 @pytest.fixture(autouse=True)
-def _clear_loader_caches() -> None:
+def _clear_loader_caches(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     codex_loader._jsonl_cache.clear()
     codex_adapter._file_cache.clear()
+    # Keep the loader away from the developer's real ~/.codex and ~/.usage:
+    # the archived-sessions dir and the JSONL disk cache would otherwise leak
+    # real entries into assertions on machines with usage history.
+    monkeypatch.setattr(
+        codex_loader, "ARCHIVED_SESSIONS_DIR", tmp_path / "archived_sessions"
+    )
+    monkeypatch.setattr(
+        codex_loader, "JSONL_CACHE_PATH", tmp_path / "codex_jsonl_cache.json"
+    )
+    monkeypatch.setattr(codex_loader, "_disk_cache_seeded", True)
 
 
 def _sum_field(entries: Sequence[object], field: str) -> int:

--- a/tests/test_html_report_snapshot.py
+++ b/tests/test_html_report_snapshot.py
@@ -23,7 +23,9 @@ class _FixedLocalDateTime(datetime):
     # local timezone varies by machine (CST locally, UTC on CI). Pinning it via
     # TZ + time.tzset() is not portable — Windows has no tzset — so pin the
     # astimezone() result itself to a fixed UTC instant.
-    def astimezone(self, tz: tzinfo | None = None) -> datetime:
+    # The override intentionally collapses every zone to a fixed plain-datetime
+    # instant, so it narrows typeshed's `-> Self`.
+    def astimezone(self, tz: tzinfo | None = None) -> datetime:  # type: ignore[override]
         del tz
         return datetime(2026, 5, 24, 10, 30, 45, tzinfo=UTC)
 

--- a/tests/test_html_report_snapshot.py
+++ b/tests/test_html_report_snapshot.py
@@ -7,9 +7,6 @@
 from __future__ import annotations
 
 import base64
-import os
-import time
-from collections.abc import Iterator
 from datetime import UTC, datetime, tzinfo
 from pathlib import Path
 from typing import Any
@@ -21,32 +18,31 @@ from ui import html_report
 SNAPSHOT_DIR = Path(__file__).resolve().parent / "fixtures" / "html_report_snapshots"
 
 
+class _FixedLocalDateTime(datetime):
+    # generate_html renders "now" as .astimezone().strftime("... %Z"), and the
+    # local timezone varies by machine (CST locally, UTC on CI). Pinning it via
+    # TZ + time.tzset() is not portable — Windows has no tzset — so pin the
+    # astimezone() result itself to a fixed UTC instant.
+    def astimezone(self, tz: tzinfo | None = None) -> datetime:
+        del tz
+        return datetime(2026, 5, 24, 10, 30, 45, tzinfo=UTC)
+
+
 class _FixedDateTime:
     @staticmethod
     def now(tz: tzinfo | None = None) -> datetime:
         fixed = datetime(2026, 5, 24, 10, 30, 45, tzinfo=UTC)
-        return fixed.astimezone(tz) if tz else fixed.replace(tzinfo=None)
+        if tz:
+            return fixed.astimezone(tz)
+        return _FixedLocalDateTime(2026, 5, 24, 10, 30, 45)
 
 
 @pytest.fixture(autouse=True)
 def _pin_nondeterministic_report_values(
     monkeypatch: pytest.MonkeyPatch,
-) -> Iterator[None]:
+) -> None:
     monkeypatch.setattr(html_report, "datetime", _FixedDateTime)
     monkeypatch.setattr(html_report, "_version", lambda: "0.15.8")
-    # generate_html renders the local timezone abbreviation via %Z, which varies
-    # by machine (CST locally, UTC on CI). Pin it so the golden is portable.
-    original_tz = os.environ.get("TZ")
-    os.environ["TZ"] = "UTC"
-    time.tzset()
-    try:
-        yield
-    finally:
-        if original_tz is None:
-            os.environ.pop("TZ", None)
-        else:
-            os.environ["TZ"] = original_tz
-        time.tzset()
 
 
 def _full_report_data() -> dict[str, Any]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,11 +108,7 @@ def test_apply_outcome_non_success_keeps_fatal_message() -> None:
     assert state.fatal_message == "still fatal"
 
 
-def test_main_win32_falls_back_to_tui_when_wintray_is_missing(
-    monkeypatch: Any, capsys: Any
-) -> None:
-    calls: list[dict[str, Any]] = []
-
+def _patch_main_for_win32(monkeypatch: Any, calls: list[dict[str, Any]]) -> None:
     async def fake_run_tui(**kwargs: Any) -> None:
         calls.append(kwargs)
 
@@ -133,9 +129,43 @@ def test_main_win32_falls_back_to_tui_when_wintray_is_missing(
     monkeypatch.setattr(main, "run_tui", fake_run_tui)
     monkeypatch.setattr(main, "_t", lambda key: "fallback")
     monkeypatch.setattr(sys, "platform", "win32")
-    monkeypatch.delitem(sys.modules, "wintray", raising=False)
+
+
+def _raise_module_not_found(missing: str) -> Any:
+    def fake_import(name: str) -> Any:
+        assert name == "wintray"
+        raise ModuleNotFoundError(f"No module named '{missing}'", name=missing)
+
+    return fake_import
+
+
+def test_main_win32_falls_back_to_tui_when_wintray_is_missing(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    calls: list[dict[str, Any]] = []
+    _patch_main_for_win32(monkeypatch, calls)
+    monkeypatch.setattr(
+        main.importlib, "import_module", _raise_module_not_found("wintray")
+    )
 
     main.main()
 
     assert calls == [{"mock": False, "interval": 60, "force_group": None}]
-    assert capsys.readouterr().out == "fallback\n"
+    assert capsys.readouterr().out == "fallback [wintray]\n"
+
+
+def test_main_win32_falls_back_to_tui_when_wintray_dependency_is_missing(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    # Regression: wintray -> panels -> panels.web_panel -> objc used to escape
+    # the fallback (exc.name != "wintray") and crash the windowed build.
+    calls: list[dict[str, Any]] = []
+    _patch_main_for_win32(monkeypatch, calls)
+    monkeypatch.setattr(
+        main.importlib, "import_module", _raise_module_not_found("objc")
+    )
+
+    main.main()
+
+    assert calls == [{"mock": False, "interval": 60, "force_group": None}]
+    assert capsys.readouterr().out == "fallback [objc]\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from typing import Any
 
@@ -144,9 +145,7 @@ def test_main_win32_falls_back_to_tui_when_wintray_is_missing(
 ) -> None:
     calls: list[dict[str, Any]] = []
     _patch_main_for_win32(monkeypatch, calls)
-    monkeypatch.setattr(
-        main.importlib, "import_module", _raise_module_not_found("wintray")
-    )
+    monkeypatch.setattr(importlib, "import_module", _raise_module_not_found("wintray"))
 
     main.main()
 
@@ -161,9 +160,7 @@ def test_main_win32_falls_back_to_tui_when_wintray_dependency_is_missing(
     # the fallback (exc.name != "wintray") and crash the windowed build.
     calls: list[dict[str, Any]] = []
     _patch_main_for_win32(monkeypatch, calls)
-    monkeypatch.setattr(
-        main.importlib, "import_module", _raise_module_not_found("objc")
-    )
+    monkeypatch.setattr(importlib, "import_module", _raise_module_not_found("objc"))
 
     main.main()
 

--- a/tests/test_panels_lazy_import.py
+++ b/tests/test_panels_lazy_import.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 lollapalooza <https://github.com/aqua5230>
+#
+# Part of "usage". Free software licensed under the GNU Affero General Public
+# License v3.0 only; see the LICENSE file for full terms and the warranty disclaimer.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_importing_panels_package_does_not_import_web_panel() -> None:
+    # Regression: panels/__init__ used to import panels.web_panel (PyObjC)
+    # eagerly, which crashed any panels.payload import on Windows and took the
+    # whole tray down with it. Run in a subprocess so this session's module
+    # cache cannot mask an eager import.
+    code = (
+        "import sys; "
+        "import panels; "
+        "import panels.payload; "
+        "assert 'panels.web_panel' not in sys.modules, "
+        "'panels.web_panel was imported eagerly'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_reporter_build_data.py
+++ b/tests/test_reporter_build_data.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Iterator
 from datetime import UTC, date, datetime, tzinfo
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import pytest
 
@@ -57,7 +57,7 @@ def _fixed_datetime(fixed: datetime) -> type:
     # no-arg astimezone() to UTC so the pinned clock is machine-zone-proof
     # (Windows cannot pin the process zone through TZ + tzset).
     class _FixedLocalDateTime(datetime):
-        def astimezone(self, tz: tzinfo | None = None) -> datetime:
+        def astimezone(self, tz: tzinfo | None = None) -> Self:
             return super().astimezone(tz if tz is not None else UTC)
 
     class _FixedDateTime:

--- a/tests/test_reporter_build_data.py
+++ b/tests/test_reporter_build_data.py
@@ -53,10 +53,19 @@ def _empty_year_payload() -> dict[str, Any]:
 
 
 def _fixed_datetime(fixed: datetime) -> type:
+    # build_report_data derives "today" via datetime.now().astimezone(); pin the
+    # no-arg astimezone() to UTC so the pinned clock is machine-zone-proof
+    # (Windows cannot pin the process zone through TZ + tzset).
+    class _FixedLocalDateTime(datetime):
+        def astimezone(self, tz: tzinfo | None = None) -> datetime:
+            return super().astimezone(tz if tz is not None else UTC)
+
     class _FixedDateTime:
         @staticmethod
         def now(tz: tzinfo | None = None) -> datetime:
-            return fixed.astimezone(tz) if tz else fixed
+            if tz:
+                return fixed.astimezone(tz)
+            return _FixedLocalDateTime.fromtimestamp(fixed.timestamp(), tz=UTC)
 
     return _FixedDateTime
 
@@ -101,6 +110,17 @@ def _sandbox_reporter_dependencies(
     os.environ["TZ"] = "UTC"
     if hasattr(time, "tzset"):
         time.tzset()
+
+    # TZ + tzset only pins the local zone on POSIX — Windows has no tzset, so
+    # entry dates would still be bucketed in the machine's zone there. Pin the
+    # conversion point itself to UTC as well.
+    def _entry_date_utc(entry: UsageEntry) -> date:
+        ts = entry.timestamp
+        if ts.tzinfo:
+            ts = ts.astimezone(UTC)
+        return ts.date()
+
+    monkeypatch.setattr(reporter, "_entry_date", _entry_date_utc)
 
     monkeypatch.setattr(reporter, "YEAR_CACHE_PATH", tmp_path / ".usage" / "year_cache.json")
     monkeypatch.setattr(reporter, "YEAR_LEDGER_PATH", tmp_path / ".usage" / "year_ledger.json")

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -869,7 +869,9 @@ def test_build_prompt_uses_explain_reminder_when_nothing_fixable(
     assert "Health check: about 2% waste came from scanning generated folders." in prompt
     assert "看" in prompt
     assert "修" not in prompt
-    assert str(snapshot) in prompt
+    # The reminder line is JSON-encoded into the prompt, which escapes the
+    # backslashes of a Windows snapshot path.
+    assert json.dumps(str(snapshot), ensure_ascii=False)[1:-1] in prompt
     state_data = json.loads(state.read_text(encoding="utf-8"))
     assert state_data["last_fingerprint"] == "fp-new"
 

--- a/tests/test_setup_hook.py
+++ b/tests/test_setup_hook.py
@@ -16,7 +16,7 @@ import pytest
 
 import session_hooks
 import setup_hook
-from tests.helpers import SetupHookPaths
+from tests.helpers import SetupHookPaths, expected_statusline_command
 
 LEGACY_NAME = "usag"
 
@@ -51,7 +51,9 @@ def test_setup_backs_up_existing_statusline_and_is_idempotent(
     assert setup_hook.setup() == 0
 
     data = json.loads(settings.read_text(encoding="utf-8"))
-    assert data["statusLine"]["command"] == f"/usr/bin/python3 {setup_hook.FORWARDER_TARGET}"
+    assert data["statusLine"]["command"] == expected_statusline_command(
+        setup_hook.FORWARDER_TARGET
+    )
     assert data["usage"]["previousStatusLine"] == original
     assert hook_target.exists()
     assert setup_hook.FORWARDER_TARGET.exists()
@@ -143,6 +145,9 @@ def test_load_settings_bad_utf8_raises_system_exit(setup_paths: SetupHookPaths) 
         setup_hook._load_settings()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="exercises POSIX shell quoting via /bin/sh"
+)
 def test_statusline_command_quotes_paths_with_spaces(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -175,6 +180,7 @@ def test_statusline_command_quotes_paths_with_spaces(
 def test_find_system_python_prefers_usr_bin_over_bundled_app_python(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(sys, "executable", "/Applications/usage.app/Contents/MacOS/python")
     monkeypatch.setattr(
         "setup_hook.os.path.exists",
@@ -491,9 +497,9 @@ def test_self_heal_migrates_bundled_python_commands(
     session_hooks._migrate_bundled_python_commands_if_needed()
 
     data = json.loads(settings.read_text(encoding="utf-8"))
-    assert data["statusLine"]["command"] == f"/usr/bin/python3 {hook_target}"
+    assert data["statusLine"]["command"] == expected_statusline_command(hook_target)
     hooks = data["hooks"]["SessionStart"][0]["hooks"]
-    assert hooks[0]["command"] == f"/usr/bin/python3 {resume_source}"
+    assert hooks[0]["command"] == expected_statusline_command(resume_source)
     migrate_entries = [
         entry
         for entry in data["usage"]["selfHealLog"]

--- a/tests/test_setup_hook_coexistence.py
+++ b/tests/test_setup_hook_coexistence.py
@@ -21,7 +21,7 @@ import main
 import setup_hook
 import usage_client
 import usage_statusline_forwarder
-from tests.helpers import SetupHookPaths
+from tests.helpers import SetupHookPaths, expected_statusline_command
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def test_install_when_no_existing_statusline(
     assert setup_hook.setup() == 0
     data = json.loads(settings.read_text(encoding="utf-8"))
 
-    assert data["statusLine"]["command"] == f"/usr/bin/python3 {hook_target}"
+    assert data["statusLine"]["command"] == expected_statusline_command(hook_target)
     assert hook_target.exists()
     assert not forwarder_target.exists()
 
@@ -61,7 +61,7 @@ def test_install_when_tt_statusline_exists(
     assert setup_hook.setup() == 0
     data = json.loads(settings.read_text(encoding="utf-8"))
 
-    assert data["statusLine"]["command"] == f"/usr/bin/python3 {forwarder_target}"
+    assert data["statusLine"]["command"] == expected_statusline_command(forwarder_target)
     assert data["usage"]["previousStatusLine"] == external
     assert hook_target.exists()
     assert forwarder_target.exists()

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -75,9 +75,9 @@ def test_draw_tray_icon_and_tooltip(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setitem(sys.modules, "PIL", fake_pil)
 
-    image = wintray.draw_tray_icon(25.0)
+    icon_image = wintray.draw_tray_icon(25.0)
 
-    assert image.size == (64, 64)
+    assert icon_image.size == (64, 64)
     assert wintray.build_tooltip(_state()).splitlines() == [
         "Claude Session: 75%",
         "Claude Weekly: 40%",

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -158,3 +158,25 @@ def test_run_app_wires_pystray_and_pywebview(
         "run_detached",
         ("start", "edgechromium"),
     ]
+
+
+def test_menu_actions_pass_real_pystray_signature_validation() -> None:
+    # Regression: pystray validates every action's co_argcount when a MenuItem
+    # is constructed, and the panel-switch lambda used to carry a third
+    # defaulted positional parameter, raising ValueError before the tray icon
+    # ever appeared. Build the menu against the real pystray to catch that.
+    pytest.importorskip("pystray", reason="pystray is a Windows-only extra")
+    controller = SimpleNamespace(
+        language="en",
+        active_panel_id="classic",
+        switch_panel=lambda panel_id: None,
+        show_panel=lambda: None,
+        refresh=lambda: None,
+        toggle_login=lambda: None,
+        check_update=lambda: None,
+        quit=lambda: None,
+    )
+
+    menu = wintray._menu(controller)  # type: ignore[arg-type]
+
+    assert menu is not None

--- a/usage_cli.py
+++ b/usage_cli.py
@@ -489,14 +489,18 @@ def _show_interactive_dashboard(agents: list[AgentInfo]) -> None:
 
 
 def _read_key_unix() -> str:
+    # The termios/tty attribute ignores are for mypy's win32 run, where the
+    # modules exist as stubs but expose no POSIX attributes; pyproject sets
+    # warn_unused_ignores=false for this module so the darwin run tolerates
+    # them (and the msvcrt ignores below, in reverse).
     import os as _os
     import select
     import tty
     import termios
     fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
+    old = termios.tcgetattr(fd)  # type: ignore[attr-defined]
     try:
-        tty.setraw(fd)
+        tty.setraw(fd)  # type: ignore[attr-defined]
         ch = _os.read(fd, 1)
         if ch == b"\x1b":
             if not select.select([fd], [], [], 0.05)[0]:
@@ -543,7 +547,7 @@ def _read_key_unix() -> str:
             return "quit"
         return "other"
     finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)  # type: ignore[attr-defined]
 
 
 def _read_key_win() -> str:

--- a/usage_session_resume.py
+++ b/usage_session_resume.py
@@ -746,8 +746,17 @@ def _format_time(parsed: datetime) -> str:
 
 def _project_from_cwd(cwd: str) -> str:
     home = os.path.expanduser("~")
-    rel = cwd[len(home):].strip(os.sep) if cwd.startswith(home) else cwd.strip(os.sep)
-    parts = rel.split(os.sep)
+    rel = cwd[len(home):] if cwd.startswith(home) else cwd
+    # Windows sessions read transcripts whose cwd may use either separator
+    # (e.g. POSIX-style paths). POSIX filenames may legitimately contain
+    # backslashes, so only normalize them on Windows.
+    if sys.platform == "win32":
+        rel = rel.replace("\\", "/")
+        sep = "/"
+    else:
+        sep = os.sep
+    rel = rel.strip(sep)
+    parts = rel.split(sep)
     return parts[-1] if parts and parts[-1] else (rel or "unknown")
 
 

--- a/wintray.py
+++ b/wintray.py
@@ -588,6 +588,8 @@ def run_app(mock: bool = False, interval: int = 60) -> None:
         on_top=True,
         hidden=True,
     )
+    if window is None:
+        raise RuntimeError("pywebview did not create a window")
     window.events.loaded += controller.on_loaded
     icon = pystray.Icon("usage", draw_tray_icon(None), "usage", _menu(controller))
     controller.attach(icon, window)

--- a/wintray.py
+++ b/wintray.py
@@ -213,10 +213,13 @@ class _RefreshData:
 
 class _JSApi:
     def __init__(self, controller: _WindowsTrayController) -> None:
-        self.controller = controller
+        # Underscore-private: pywebview serializes every public attribute of a
+        # js_api object into the JS bridge, and walking the controller (and its
+        # WinForms window graph) recurses forever.
+        self._controller = controller
 
     def postMessage(self, message: object) -> None:  # noqa: N802 - JavaScript contract
-        self.controller.handle_panel_message(message)
+        self._controller.handle_panel_message(message)
 
 
 class _WindowsTrayController:
@@ -547,7 +550,9 @@ def _menu(controller: _WindowsTrayController) -> Any:
     panel_items = tuple(
         pystray.MenuItem(
             _t(controller.language, key),
-            lambda _icon, _item, panel_id=panel_id: controller.switch_panel(panel_id),
+            # pystray rejects actions whose co_argcount isn't 0/1/2, so the
+            # panel_id binding must be keyword-only.
+            lambda _icon, _item, *, panel_id=panel_id: controller.switch_panel(panel_id),
             checked=lambda _item, panel_id=panel_id: controller.active_panel_id == panel_id,
             radio=True,
         )


### PR DESCRIPTION
## Problem

The `check-windows` CI job has been red since it was introduced (first run on the 0.28.0 release commit), and the Windows tray never actually starts — from source or from the released `usage-windows.zip`:

1. **Tray dead on arrival.** `wintray` imports `panels.payload`, which executes `panels/__init__`, which eagerly imported the PyObjC-backed `panels.web_panel` → `ModuleNotFoundError: No module named 'objc'` on Windows. The fallback in `main.py` only recognized a missing `wintray` module (`exc.name != "wintray"` → re-raise), so the `--windowed` build exited silently with nothing on screen.
2. **Two more crashes were hiding behind it.** Once the import chain is fixed: pystray rejects the panel-switch lambda (its captured `panel_id` default made `co_argcount == 3`) with `ValueError` before the icon appears; and pywebview serializes every public attribute of the `js_api` object, so exposing the controller walked the WinForms graph (`window.native.AccessibilityObject.Bounds.Empty...`) to the recursion limit.
3. **The test suite couldn't even collect on Windows** (5 modules import PyObjC code at module level), and behind that: `TZ` + `time.tzset()` pinning silently no-ops on Windows, setup-hook tests hardcode `/usr/bin/python3` and `/bin/sh`, two `project_from_cwd` implementations split on `os.sep` only, and the Codex adapter/consistency tests leaked real `~/.codex` history into assertions on any machine with usage data (any OS — `ARCHIVED_SESSIONS_DIR` and the JSONL disk cache were not sandboxed).

## Fixes

- `panels/__init__`: build the registry lazily inside `@cache all_panels()`; macOS behavior unchanged (the PyObjC import happens on first registry access, before any view is built — verified against all `menubar.py` call sites).
- `main.py`: degrade to the TUI on any `ModuleNotFoundError` in the tray's import chain, printing the missing module's name.
- `wintray.py`: keyword-only `panel_id` binding (with a regression test against the real pystray validator); `_JSApi` holds the controller in a private attribute; guard `create_window` returning `None`.
- `usage_session_resume._project_from_cwd` + `adapters.claude.project_from_cwd`: normalize separators on Windows before splitting (POSIX untouched — backslashes are legal in POSIX filenames).
- Tests: `collect_ignore` for the PyObjC-only modules outside macOS; timezone conversion points pinned directly instead of via `tzset`; platform-derived expected hook commands; codex loader sandboxing.
- mypy: typed the platform-conditional paths (`termios`/`msvcrt` readers, `os.getuid`, `time.tzset`, pywebview `Window | None`) and **enabled the mypy step in `check-windows`** — it was skipped, which is how these defects went unnoticed.

## Verification

On Windows 11 (Python 3.13.10, uv, WebView2 Runtime 150.0.4078.65):

- `uv run ruff check` ✅ · `uv run mypy .` ✅ **0 errors, 138 files** (previously 13+ errors, step skipped in CI) · `uv run pytest -v` ✅ **681 passed, 2 skipped** (previously: collection aborted with 6 errors; after that, 20 failures + 10 errors)
- `uv run python scripts/check_doc_parity.py` ✅ (CHANGELOG updated bilingually)
- `python main.py --mock` now shows the tray icon and WebView2 panel (previously: instant silent exit)

macOS is unaffected by design; I could not run the macOS CI jobs locally, so please let CI confirm the darwin side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)