### PR TITLE
fix(windows): anchor encoded project-path decoding at the drive root

### DIFF
--- a/project_resolver.py
+++ b/project_resolver.py
@@ -68,7 +68,8 @@ def project_from_encoded_path(jsonl_path: Path, projects_dir: Path) -> str:
     if not parts:
         return "unknown"
 
-    slash_candidate = Path(os.sep, *parts)
+    root, start = _encoded_path_root(parts)
+    slash_candidate = root.joinpath(*parts[start:])
     if slash_candidate.is_dir():
         return slash_candidate.name or "unknown"
 
@@ -93,4 +94,17 @@ def _existing_encoded_project_path(parts: list[str]) -> Path | None:
                 return result
         return None
 
-    return search(0, Path(os.sep))
+    root, start = _encoded_path_root(parts)
+    return search(start, root)
+
+
+def _encoded_path_root(parts: list[str]) -> tuple[Path, int]:
+    """Return the filesystem root and first encoded component to search."""
+    if (
+        os.sep == "\\"
+        and len(parts[0]) == 2
+        and parts[0][0].isalpha()
+        and parts[0][1] == ":"
+    ):
+        return Path(parts[0] + os.sep), 1
+    return Path(os.sep), 0

--- a/tests/test_project_resolver.py
+++ b/tests/test_project_resolver.py
@@ -151,6 +151,19 @@ def test_project_from_encoded_path_resolves_existing_dash_dir(tmp_path: Path) ->
     assert result == "claude-tutorial-video"
 
 
+def test_encoded_path_root_uses_windows_drive_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(os, "sep", "\\")
+
+    root, start = project_resolver._encoded_path_root(
+        ["C:", "Users", "runneradmin", "AppData", "Local", "Temp", "alpha"]
+    )
+
+    assert str(root) == "C:\\"
+    assert start == 1
+
+
 def test_project_from_encoded_path_fallback_preserves_dash(tmp_path: Path) -> None:
     projects_dir = tmp_path / "projects"
 


### PR DESCRIPTION
## Problem

`check-windows` fails on both #63 and #64 for a reason unrelated to either PR: `project_from_encoded_path` / `_existing_encoded_project_path` in `project_resolver.py` decode a Claude Code project directory's dash-encoded name back to a real path by searching the filesystem from `Path(os.sep)`.

On POSIX, `os.sep` is `/`, and `Path("/")` is the real filesystem root — fine. On Windows, `os.sep` is `\`, and a bare `Path("\\")` has no drive letter, so it never matches a real directory (e.g. `C:\Users\...`). Decoding always falls through to the ugly fully-encoded fallback string instead of the clean project name, which is what's failing 6 tests on the GitHub Actions Windows runner.

## Fix

Add `_encoded_path_root()`: when the first encoded segment looks like a drive letter (e.g. `"C:"`), anchor the search at `C:\` and skip that segment; otherwise behave exactly as before. POSIX is untouched.

## Verification

- `uv run ruff check` / `uv run mypy .` / `uv run pytest -q` all green (823 passed) on macOS.
- New regression test simulates a Windows-style encoded path (`["C:", "Users", "runneradmin", ..., "alpha"]`) and asserts the root anchors at `C:\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)