### PR TITLE
Fix Windows panel reload and bundled hooks

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -26,6 +26,11 @@ try {
         --add-data "$(Join-Path $RepoRoot 'i18n.json');." `
         --add-data "$(Join-Path $RepoRoot 'pyproject.toml');." `
         --add-data "$(Join-Path $RepoRoot 'assets');assets" `
+        --add-data "$(Join-Path $RepoRoot 'usage_statusline.py');." `
+        --add-data "$(Join-Path $RepoRoot 'usage_statusline_forwarder.py');." `
+        --add-data "$(Join-Path $RepoRoot 'usage_session_resume.py');." `
+        --add-data "$(Join-Path $RepoRoot 'usage_terse_mode.py');." `
+        --add-data "$(Join-Path $RepoRoot 'usage_terse_reminder.py');." `
         --hidden-import wintray `
         --hidden-import pystray `
         --hidden-import webview `

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -112,22 +112,58 @@ def test_js_api_forwards_panel_message() -> None:
 def test_switch_panel_waits_for_bridge_promise_to_resolve(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    scheduled: list[tuple[float, object, tuple[object, ...]]] = []
+    scheduled: list[FakeTimer] = []
 
     class FakeTimer:
-        def __init__(self, delay: float, callback: object, args: tuple[object, ...]) -> None:
-            scheduled.append((delay, callback, args))
+        def __init__(self, delay: float, callback: object) -> None:
+            self.delay = delay
+            self.callback = callback
+            scheduled.append(self)
+
+        def start(self) -> None:
+            return None
+
+        def fire(self) -> None:
+            assert callable(self.callback)
+            self.callback()
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.active_panel_id = "classic"
+    switched_to: list[str] = []
+    monkeypatch.setattr(controller, "switch_panel", switched_to.append)
+    monkeypatch.setattr(threading, "Timer", FakeTimer)
+
+    controller.handle_panel_message("switch")
+
+    assert len(scheduled) == 1
+    assert scheduled[0].delay == 0.05
+    assert switched_to == []
+
+    controller.active_panel_id = "matrix"
+    scheduled[0].fire()
+
+    assert switched_to == ["win95"]
+
+
+def test_switch_panel_ignores_second_click_while_switch_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduled: list[object] = []
+
+    class FakeTimer:
+        def __init__(self, delay: float, callback: object) -> None:
+            scheduled.append((delay, callback))
 
         def start(self) -> None:
             return None
 
     controller = wintray._WindowsTrayController(mock=True, interval=60)
-    controller.active_panel_id = "classic"
     monkeypatch.setattr(threading, "Timer", FakeTimer)
 
     controller.handle_panel_message("switch")
+    controller.handle_panel_message("switch")
 
-    assert scheduled == [(0.05, controller.switch_panel, ("matrix",))]
+    assert len(scheduled) == 1
 
 
 def test_run_app_wires_pystray_and_pywebview(

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -106,6 +107,27 @@ def test_js_api_forwards_panel_message() -> None:
     wintray._JSApi(controller).postMessage("refresh")  # type: ignore[arg-type]
 
     assert received == ["refresh"]
+
+
+def test_switch_panel_waits_for_bridge_promise_to_resolve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduled: list[tuple[float, object, tuple[object, ...]]] = []
+
+    class FakeTimer:
+        def __init__(self, delay: float, callback: object, args: tuple[object, ...]) -> None:
+            scheduled.append((delay, callback, args))
+
+        def start(self) -> None:
+            return None
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.active_panel_id = "classic"
+    monkeypatch.setattr(threading, "Timer", FakeTimer)
+
+    controller.handle_panel_message("switch")
+
+    assert scheduled == [(0.05, controller.switch_panel, ("matrix",))]
 
 
 def test_run_app_wires_pystray_and_pywebview(

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -13,6 +13,30 @@ import menubar_state
 import wintray
 
 
+class _Key:
+    def __enter__(self) -> _Key:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class FakeWinreg:
+    HKEY_CURRENT_USER = object()
+
+    def __init__(self, value: int = 1, error: Exception | None = None) -> None:
+        self.value = value
+        self.error = error
+
+    def OpenKey(self, *args: object) -> _Key:  # noqa: N802 - winreg contract
+        if self.error is not None:
+            raise self.error
+        return _Key()
+
+    def QueryValueEx(self, key: object, name: str) -> tuple[int, int]:  # noqa: N802
+        return (self.value, 4)
+
+
 def _state() -> menubar_state.PopoverState:
     row = menubar_state.QuotaRowState(
         title="Session",
@@ -91,6 +115,30 @@ def test_windows_panels_exclude_talent_market() -> None:
 
     assert "classic" in ids
     assert "talent_market" not in ids
+
+
+def test_system_background_color_dark(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wintray, "_winreg", lambda: FakeWinreg(value=0))
+
+    assert wintray._system_background_color() == "#080d12"
+
+
+def test_system_background_color_light(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wintray, "_winreg", lambda: FakeWinreg(value=1))
+
+    assert wintray._system_background_color() == "#eef2f7"
+
+
+def test_system_background_color_falls_back_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        wintray,
+        "_winreg",
+        lambda: FakeWinreg(error=OSError("registry unavailable")),
+    )
+
+    assert wintray._system_background_color() == "#eef2f7"
 
 
 def test_panel_html_installs_webkit_shim_without_changing_asset() -> None:
@@ -194,7 +242,9 @@ def test_run_app_wires_pystray_and_pywebview(
     window = SimpleNamespace(events=SimpleNamespace(loaded=Event()))
 
     def create_window(*args: object, **kwargs: object) -> object:
-        events.append(("window", args[0], kwargs["hidden"]))
+        events.append(
+            ("window", args[0], kwargs["hidden"], kwargs["background_color"])
+        )
         return window
 
     fake_pystray = SimpleNamespace(Icon=FakeIcon, Menu=FakeMenu, MenuItem=FakeMenuItem)
@@ -205,12 +255,13 @@ def test_run_app_wires_pystray_and_pywebview(
     monkeypatch.setitem(sys.modules, "pystray", fake_pystray)
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
     monkeypatch.setattr(wintray, "draw_tray_icon", lambda value: object())
+    monkeypatch.setattr(wintray, "_system_background_color", lambda: "#eef2f7")
     monkeypatch.setattr(wintray._WindowsTrayController, "attach", lambda self, icon, view: None)
 
     wintray.run_app(mock=True, interval=60)
 
     assert events == [
-        ("window", "usage", True),
+        ("window", "usage", True, "#eef2f7"),
         "loaded_handler",
         ("icon", "usage"),
         "run_detached",

--- a/wintray.py
+++ b/wintray.py
@@ -500,7 +500,12 @@ class _WindowsTrayController:
             self.quit()
         elif action == "switch":
             ids = [panel[0] for panel in available_panels()]
-            self.switch_panel(ids[(ids.index(self.active_panel_id) + 1) % len(ids)])
+            next_panel_id = ids[(ids.index(self.active_panel_id) + 1) % len(ids)]
+            # postMessage is a pywebview promise. Reloading the document before
+            # that promise resolves destroys its callback and can leave the
+            # Edge WebView as a blank white window. Defer the reload until the
+            # bridge call has returned to JavaScript.
+            threading.Timer(0.05, self.switch_panel, args=(next_panel_id,)).start()
         elif action in {"toggle_statusline", "toggle-statusline"}:
             threading.Thread(target=self._toggle_statusline, daemon=True).start()
         elif action == "install":

--- a/wintray.py
+++ b/wintray.py
@@ -228,6 +228,7 @@ class _WindowsTrayController:
         self.interval = max(30, interval)
         self.language = detect_lang()
         self.active_panel_id = _active_panel_id()
+        self._switch_pending: bool = False
         self.latest_state = self._empty_state()
         self.tracker = UsageRateTracker(mock=mock)
         self.burn_rate_trackers = {
@@ -445,6 +446,12 @@ class _WindowsTrayController:
         _save_active_panel_id(panel_id)
         self.window.load_html(panel_html(self.panel_filename()))
 
+    def _deferred_switch_panel(self) -> None:
+        self._switch_pending = False
+        ids = [panel[0] for panel in available_panels()]
+        next_panel_id = ids[(ids.index(self.active_panel_id) + 1) % len(ids)]
+        self.switch_panel(next_panel_id)
+
     def toggle_login(self, _icon: Any = None, _item: Any = None) -> None:
         win_login_item.disable() if win_login_item.is_enabled() else win_login_item.enable()
 
@@ -499,13 +506,17 @@ class _WindowsTrayController:
         elif action == "quit":
             self.quit()
         elif action == "switch":
-            ids = [panel[0] for panel in available_panels()]
-            next_panel_id = ids[(ids.index(self.active_panel_id) + 1) % len(ids)]
+            if self._switch_pending:
+                return
+            self._switch_pending = True
             # postMessage is a pywebview promise. Reloading the document before
             # that promise resolves destroys its callback and can leave the
             # Edge WebView as a blank white window. Defer the reload until the
-            # bridge call has returned to JavaScript.
-            threading.Timer(0.05, self.switch_panel, args=(next_panel_id,)).start()
+            # bridge call has returned to JavaScript. This empirical delay is
+            # not a synchronization guarantee. If slow machines still show a
+            # blank window, JavaScript must call a second API after postMessage's
+            # promise resolves to trigger the reload; do not increase this delay.
+            threading.Timer(0.05, self._deferred_switch_panel).start()
         elif action in {"toggle_statusline", "toggle-statusline"}:
             threading.Thread(target=self._toggle_statusline, daemon=True).start()
         elif action == "install":

--- a/wintray.py
+++ b/wintray.py
@@ -81,6 +81,27 @@ window.webkit.messageHandlers.usage = {
 """.strip()
 
 
+def _winreg() -> Any:
+    import winreg
+
+    return winreg
+
+
+def _system_background_color() -> str:
+    try:
+        winreg = _winreg()
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+        ) as key:
+            value, _value_type = winreg.QueryValueEx(key, "AppsUseLightTheme")
+        if value == 0:
+            return "#080d12"
+    except Exception:
+        pass
+    return "#eef2f7"
+
+
 def available_panels() -> tuple[tuple[str, str, str], ...]:
     """Windows excludes talent_market because its vendored CLI is macOS-only."""
     return tuple(panel for panel in WINDOWS_PANELS if panel[0] != "talent_market")
@@ -603,6 +624,7 @@ def run_app(mock: bool = False, interval: int = 60) -> None:
         easy_drag=False,
         on_top=True,
         hidden=True,
+        background_color=_system_background_color(),
     )
     if window is None:
         raise RuntimeError("pywebview did not create a window")


### PR DESCRIPTION
## What changed

- defer Windows panel reloads until the pywebview bridge promise has returned
- include status-line and session hook source files in the Windows PyInstaller bundle
- add a regression test for the deferred panel switch

## Why

Switching panels synchronously from the pywebview API callback destroyed the JavaScript return callback while it was still in flight. Edge WebView could then remain as a blank white window. The Windows bundle also omitted hook source files that the setup and self-heal paths copy at runtime.

## Impact

Windows users can switch panel themes without hitting a blank window, and bundled status-line/session setup can find the required source files.

## Validation

- `pytest -q tests/test_wintray.py` — 12 passed
- `ruff check wintray.py tests/test_wintray.py`
- `mypy wintray.py tests/test_wintray.py`
- rebuilt the Windows PyInstaller bundle and launched `usage.exe` successfully
