### PR TITLE
Fix Windows agy quota probe: read new CLI token from Credential Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 All notable changes to usage are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+- **Antigravity quota probing now reads the current Windows CLI OAuth credential**: when the legacy token file is missing or unusable, usage falls back read-only to the `gemini:antigravity` Windows Credential Manager entry. The quota request's user agent now also identifies the actual host platform instead of always claiming Darwin/arm64.
+
 ## [0.28.2] - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -4,6 +4,11 @@
 
 本檔記錄 usage 所有重要變更。格式參考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## Unreleased
+
+### 修正
+- **Antigravity 額度探測現在會讀取 Windows CLI 目前的 OAuth 憑證**：舊版 token 檔案不存在或不可用時，usage 會唯讀退回 Windows Credential Manager 的 `gemini:antigravity` 項目。額度請求的 user agent 也會識別實際主機平台，不再一律宣稱是 Darwin/arm64。
+
 ## [0.28.2] - 2026-07-15
 
 ### 修正

--- a/agy_quota_probe.py
+++ b/agy_quota_probe.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
+import sys
 import tempfile
 import time
 import urllib.parse
@@ -24,6 +26,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -37,7 +40,14 @@ _QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSu
 # Antigravity's installed-app public client constants (same values quotio ships).
 _CLIENT_ID = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 _CLIENT_SECRET = "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"
-_USER_AGENT = "antigravity/1.11.3 Darwin/arm64"
+
+
+def _user_agent() -> str:
+    """Build the Antigravity client identifier for the host platform."""
+    return f"antigravity/1.11.3 {platform.system()}/{platform.machine()}"
+
+
+_USER_AGENT = _user_agent()
 
 # In-memory cache of a refreshed access token so each probe does not re-refresh.
 # Holds {"access_token": str, "expires_monotonic": float}.
@@ -130,6 +140,8 @@ def _resolve_access_token(timeout: float) -> str | None:
         return cached_token
 
     token_data = _read_token_file()
+    if not _has_usable_token(token_data) and sys.platform == "win32":
+        token_data = _read_windows_credential()
     if not isinstance(token_data, dict):
         return None
     token = token_data.get("token")
@@ -163,6 +175,87 @@ def _read_token_file() -> object:
             return json.load(handle)
     except (OSError, ValueError):
         return None
+
+
+def _has_usable_token(token_data: object) -> bool:
+    """Return whether a token payload has the fields needed to resolve access."""
+    if not isinstance(token_data, dict):
+        return False
+    token = token_data.get("token")
+    if not isinstance(token, dict):
+        return False
+    access_token = token.get("access_token")
+    expiry = token.get("expiry")
+    return (
+        isinstance(access_token, str)
+        and bool(access_token)
+        and isinstance(expiry, str)
+        and _parse_timestamp(expiry) is not None
+    )
+
+
+def _windows_ctypes() -> tuple[Any, Any]:
+    """Lazily import Windows-only ctypes helpers so this module stays portable."""
+    import ctypes
+    from ctypes import wintypes
+
+    return ctypes, wintypes
+
+
+def _read_windows_credential() -> object:
+    """Read the Antigravity OAuth credential from Windows Credential Manager.
+
+    Read-only: we never write back to Credential Manager (that is the CLI's
+    home and changing it would risk corrupting its login).
+    """
+    if sys.platform != "win32":
+        return None
+
+    ctypes, wintypes = _windows_ctypes()
+
+    class _Credential(ctypes.Structure):  # type: ignore[name-defined, misc]
+        _fields_ = [
+            ("Flags", wintypes.DWORD),
+            ("Type", wintypes.DWORD),
+            ("TargetName", wintypes.LPWSTR),
+            ("Comment", wintypes.LPWSTR),
+            ("LastWritten", wintypes.FILETIME),
+            ("CredentialBlobSize", wintypes.DWORD),
+            ("CredentialBlob", ctypes.POINTER(wintypes.BYTE)),
+            ("Persist", wintypes.DWORD),
+            ("AttributeCount", wintypes.DWORD),
+            ("Attributes", wintypes.LPVOID),
+            ("TargetAlias", wintypes.LPWSTR),
+            ("UserName", wintypes.LPWSTR),
+        ]
+
+    credential = ctypes.POINTER(_Credential)()
+    cred_read = ctypes.windll.advapi32.CredReadW
+    cred_read.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(ctypes.POINTER(_Credential)),
+    ]
+    cred_read.restype = wintypes.BOOL
+    if not cred_read("gemini:antigravity", 1, 0, ctypes.byref(credential)):
+        return None
+    try:
+        size = credential.contents.CredentialBlobSize
+        blob = ctypes.string_at(credential.contents.CredentialBlob, size)
+    finally:
+        ctypes.windll.advapi32.CredFree(credential)
+    return _parse_windows_credential_blob(blob)
+
+
+def _parse_windows_credential_blob(blob: bytes) -> object:
+    """Parse a CredentialBlob, normally UTF-16LE JSON written by the CLI."""
+    for encoding in ("utf-16-le", "utf-8"):
+        try:
+            return json.loads(blob.decode(encoding).lstrip("\ufeff").rstrip("\x00"))
+        except (UnicodeDecodeError, ValueError):
+            continue
+    return None
 
 
 def _refresh_token(refresh_token: str, timeout: float) -> tuple[str, int] | None:

--- a/tests/test_agy_quota_probe.py
+++ b/tests/test_agy_quota_probe.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
+import sys
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -144,6 +146,43 @@ def test_resolve_access_token_uses_disk_token_when_not_expired(
 
     assert agy_quota_probe._resolve_access_token(15.0) == "fresh-from-disk"
     assert visited == []  # no refresh, no API call
+
+
+def test_resolve_access_token_falls_back_to_windows_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(agy_quota_probe, "_TOKEN_PATH", Path("missing-antigravity-token"))
+    monkeypatch.setattr(sys, "platform", "win32")
+    credential_payload = {
+        "token": {
+            "access_token": "fresh-from-credential-manager",
+            "expiry": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        }
+    }
+    calls: list[None] = []
+
+    def read_credential() -> object:
+        calls.append(None)
+        return credential_payload
+
+    monkeypatch.setattr(agy_quota_probe, "_read_windows_credential", read_credential)
+
+    assert agy_quota_probe._resolve_access_token(15.0) == "fresh-from-credential-manager"
+    assert calls == [None]
+
+
+def test_parse_windows_credential_blob_reads_utf16le_json() -> None:
+    payload = {"token": {"access_token": "credential-token", "expiry": "2030-01-01T00:00:00Z"}}
+    blob = json.dumps(payload).encode("utf-16-le")
+
+    assert agy_quota_probe._parse_windows_credential_blob(blob) == payload
+
+
+def test_user_agent_uses_current_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(platform, "machine", lambda: "AMD64")
+
+    assert agy_quota_probe._user_agent() == "antigravity/1.11.3 Windows/AMD64"
 
 
 def test_resolve_access_token_refreshes_when_expired(
@@ -349,6 +388,7 @@ def test_probe_quota_returns_none_without_token_file(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(agy_quota_probe, "_TOKEN_PATH", tmp_path / "missing-token")
+    monkeypatch.setattr(agy_quota_probe, "_read_windows_credential", lambda: None)
     urlopen, visited = _build_urlopen({})
     monkeypatch.setattr(agy_quota_probe, "urlopen", urlopen)
 


### PR DESCRIPTION
## Summary
- The Antigravity CLI now stores its OAuth token in Windows Credential Manager (`gemini:antigravity`) instead of only the legacy plaintext file at `~/.gemini/antigravity-cli/antigravity-oauth-token`, which had gone stale on updated installs. `_resolve_access_token` now falls back read-only to `CredReadW` (stdlib `ctypes`, no `pywin32`/`keyring`) on Windows when the disk token is missing or unusable; the disk path is still tried first, so unmigrated installs are unaffected.
- Fixes `_USER_AGENT`, which was hardcoded to `antigravity/1.11.3 Darwin/arm64` and sent that string on every platform; it now reflects the actual host platform.
- Bilingual `CHANGELOG.md` / `CHANGELOG.zh-TW.md` entries added under Unreleased.

## Test plan
- [x] `ruff check` — clean
- [x] `mypy .` — clean
- [x] `pytest -v` — 700 passed, 2 skipped (pre-existing, environment-specific: `tzset unavailable`, POSIX shell-quoting test skipped on Windows)
- [x] New tests cover the Credential Manager fallback, blob parsing, and platform-aware user agent, all via `monkeypatch` — no real `~/.claude/`, `~/.codex/`, or Windows Credential Manager access in the test suite
- [x] Fixed a pre-existing test (`test_probe_quota_returns_none_without_token_file`) that, without this PR's added isolation, would have read this machine's real Windows Credential Manager entry when run on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)