### PR TITLE
Fix the Windows status-file lock silently degrading to no lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 All notable changes to usage are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+- **The status line no longer drops quota data when two Claude Code instances refresh at once on Windows**: the hook's file lock was blocking on POSIX (`fcntl.flock(LOCK_EX)`) but non-blocking on Windows (`msvcrt.locking(LK_NBLCK)`), and a contended lock raised `OSError` that was swallowed — leaving the `rate_limits` carry-forward read-modify-write in `save()` completely unsynchronized. Windows now polls the lock until it is acquired (10s deadline), matching POSIX semantics; genuinely unsupported locking still falls back to the atomic write alone. Measured over 200 concurrent hook pairs: `rate_limits` were lost 21 times before, 0 times after.
+
 ## [0.28.2] - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -4,6 +4,11 @@
 
 本檔記錄 usage 所有重要變更。格式參考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## Unreleased
+
+### 修正
+- **Windows 上兩個 Claude Code 同時刷新時，狀態列不再掉失額度資料**：hook 的檔案鎖在 POSIX 上是阻塞式的（`fcntl.flock(LOCK_EX)`），在 Windows 上卻是非阻塞的（`msvcrt.locking(LK_NBLCK)`），而搶鎖失敗拋出的 `OSError` 被吞掉——導致 `save()` 裡 `rate_limits` 的 carry-forward 讀改寫完全沒有同步保護。Windows 現在會輪詢直到取得鎖（10 秒上限），語意與 POSIX 一致；若該檔案系統真的不支援鎖定，仍退回單靠原子寫入。實測 200 組並行 hook：修正前掉失 `rate_limits` 21 次，修正後 0 次。
+
 ## [0.28.2] - 2026-07-15
 
 ### 修正

--- a/tests/test_usage_statusline.py
+++ b/tests/test_usage_statusline.py
@@ -6,10 +6,12 @@
 
 from __future__ import annotations
 
+import errno
 import io
 import json
 import os
 import sys
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -60,6 +62,72 @@ def test_save_works_without_fcntl_or_msvcrt(
     usage_statusline.save({"rate_limits": {"status": "ok"}}, datetime.now(UTC))
 
     assert status_file.exists()
+
+
+def test_acquire_msvcrt_lock_waits_out_a_contended_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression: LK_NBLCK gives up instantly, and the caller used to swallow
+    # that and run save()'s read-modify-write unlocked — unlike the blocking
+    # fcntl.flock on POSIX.
+    attempts = []
+
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 0
+
+        def locking(self, fd: int, mode: int, nbytes: int) -> None:
+            attempts.append(mode)
+            if len(attempts) < 3:
+                raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(usage_statusline, "msvcrt", FakeMsvcrt())
+    monkeypatch.setattr(usage_statusline, "_LOCK_POLL_INTERVAL_S", 0)
+
+    with tempfile.TemporaryFile() as handle:
+        assert usage_statusline._acquire_msvcrt_lock(handle.fileno()) is True
+
+    assert len(attempts) == 3
+
+
+def test_acquire_msvcrt_lock_gives_up_at_the_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 0
+
+        def locking(self, fd: int, mode: int, nbytes: int) -> None:
+            raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(usage_statusline, "msvcrt", FakeMsvcrt())
+    monkeypatch.setattr(usage_statusline, "_LOCK_POLL_INTERVAL_S", 0)
+    monkeypatch.setattr(usage_statusline, "_LOCK_TIMEOUT_S", 0.01)
+
+    with tempfile.TemporaryFile() as handle:
+        assert usage_statusline._acquire_msvcrt_lock(handle.fileno()) is False
+
+
+def test_acquire_msvcrt_lock_does_not_spin_when_locking_is_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = []
+
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 0
+
+        def locking(self, fd: int, mode: int, nbytes: int) -> None:
+            attempts.append(mode)
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+    monkeypatch.setattr(usage_statusline, "msvcrt", FakeMsvcrt())
+    monkeypatch.setattr(usage_statusline, "_LOCK_POLL_INTERVAL_S", 0)
+
+    with tempfile.TemporaryFile() as handle:
+        assert usage_statusline._acquire_msvcrt_lock(handle.fileno()) is False
+
+    assert len(attempts) == 1
 
 
 def test_save_preserves_existing_complete_rate_limits_when_new_data_is_incomplete(

--- a/usage_statusline.py
+++ b/usage_statusline.py
@@ -20,10 +20,12 @@ usage 主程式會反向讀這個檔，呈現給 menubar / TUI。
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
 import tempfile
+import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -51,6 +53,12 @@ __version__ = "1.0"
 
 STATUS_FILE = os.path.expanduser("~/.claude/usage-status.json")
 LOCK_FILE = os.path.expanduser("~/.claude/usage-status.lock")
+# Windows lock acquisition: poll rather than fail instantly on contention.
+_LOCK_TIMEOUT_S = 10.0
+_LOCK_POLL_INTERVAL_S = 0.001
+# msvcrt.locking reports a contended byte as EACCES; EDEADLOCK is what it
+# raises once its own internal retries are exhausted.
+_LOCK_CONTENDED_ERRNOS = frozenset((errno.EACCES, errno.EDEADLOCK, errno.EDEADLK))
 PREFERENCES_FILE = os.path.expanduser("~/.claude/usage-preferences.json")
 CONTEXT_BURN_FILE = os.path.expanduser("~/.claude/usage-context-burn.json")
 UPDATE_HINT_STALE_SECONDS = 30 * 86400
@@ -252,6 +260,33 @@ def _rate_limits_complete(rate_limits: Any) -> bool:
     return five.get("used_percentage") is not None and seven.get("used_percentage") is not None
 
 
+def _acquire_msvcrt_lock(lock_fd: int) -> bool:
+    """Block (bounded) until the byte is locked; False if locking is unavailable.
+
+    msvcrt has no blocking-with-timeout mode: LK_LOCK retries on a fixed
+    one-second granularity, and LK_NBLCK gives up instantly. Poll LK_NBLCK so a
+    contended lock is waited out rather than silently skipped — dropping the
+    lock would run save()'s read-modify-write unsynchronized, which fcntl.flock
+    never does on POSIX.
+    """
+    deadline = time.monotonic() + _LOCK_TIMEOUT_S
+    while True:
+        try:
+            if os.fstat(lock_fd).st_size == 0:
+                os.write(lock_fd, b"\0")
+            os.lseek(lock_fd, 0, os.SEEK_SET)
+            msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as exc:
+            if exc.errno not in _LOCK_CONTENDED_ERRNOS:
+                # Locking is unsupported on this descriptor or filesystem;
+                # spinning would not help. Fall back to the atomic write alone.
+                return False
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_LOCK_POLL_INTERVAL_S)
+
+
 @contextmanager
 def _exclusive_lock(lock_fd: int) -> Any:
     """Use the native lock when available; preserve atomic writes without one."""
@@ -263,16 +298,7 @@ def _exclusive_lock(lock_fd: int) -> Any:
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
         return
 
-    locked = False
-    if msvcrt is not None:
-        try:
-            if os.fstat(lock_fd).st_size == 0:
-                os.write(lock_fd, b"\0")
-            os.lseek(lock_fd, 0, os.SEEK_SET)
-            msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
-            locked = True
-        except OSError:
-            pass
+    locked = _acquire_msvcrt_lock(lock_fd) if msvcrt is not None else False
     try:
         yield
     finally:


### PR DESCRIPTION
## Problem

`usage_statusline._exclusive_lock()` guards `save()`'s `rate_limits` carry-forward — the read-modify-write at usage_statusline.py:298-311 that keeps a payload without `rate_limits` from wiping the ones already on disk.

On POSIX that guard is real: `fcntl.flock(lock_fd, fcntl.LOCK_EX)` (usage_statusline.py:259) blocks until acquired.

On Windows it is not. `msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)` returns immediately with `OSError` when another process holds the byte, and the `except OSError: pass` below it swallows that and falls through into the critical section with `locked = False`. The one case the lock exists for — contention — is handled identically to "this filesystem doesn't support locking".

The window is not theoretical. Two hook processes with genuinely overlapping lifetimes race the read at :300 against the `os.replace()` at :311; the loser reads the pre-replace file (or gets a Windows sharing violation, which `except (OSError, ...)` at :302 reinterprets as "there is no existing data") and writes a payload with no `rate_limits`. It is also sticky rather than self-healing: once `rate_limits` are gone, every subsequent payload lacking them reads a file lacking them and cannot carry anything forward — until the next payload that actually carries `rate_limits` arrives, which is precisely the infrequent event the carry-forward exists to paper over.

Who hits it: Windows users running more than one Claude Code instance whose status lines refresh concurrently (e.g. an interactive session plus a resident headless one). POSIX users are unaffected — their lock blocks.

## Fix

Poll `LK_NBLCK` until acquired with a 10s deadline (`msvcrt` has no blocking-with-timeout mode: `LK_LOCK` retries on a fixed 1s granularity and `LK_NBLCK` gives up instantly), and distinguish the two swallowed cases by errno — contention (`EACCES`/`EDEADLOCK`) waits, anything else means locking is genuinely unavailable on this descriptor and falls back to the bare atomic write exactly as before. POSIX behavior, the `fcntl is None and msvcrt is None` fallback, and the file format are all untouched.

## Validation

Windows 11, Python 3.13.10. Stress harness runs pairs of real hook processes with both stdins written and closed before either is waited on, so the two genuinely overlap (a naive harness serializes them, because `main()` starts with `sys.stdin.read()`), then checks whether the status file still carries `rate_limits`:

```
                                        lost_rate_limits   hook_errors
v0.28.2 (LK_NBLCK, swallow)                  21/200            0
this PR (bounded polling acquire)             0/200            0
```

- `uv run ruff check` / `uv run mypy .` (0 errors, 138 files) / `uv run pytest -q` — 700 passed, 2 expected skips; bilingual CHANGELOG parity passes.
- Three new unit tests cover the contended-then-acquired path, the deadline give-up, and the no-spin-when-unsupported path, all with a fake `msvcrt` so they run on any platform.
- `usage_statusline.py` stays stdlib-only and 3.9-compatible (`errno` + `time` are the only new imports).

Independent of #69 (tray ghost window / single instance) — different file, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)