### PR TITLE
fix: Windows tray fallback overriding fresh quota, cache history scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ build = [
 [tool.ruff]
 target-version = "py313"
 line-length = 100
+extend-exclude = ["release-win"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
@@ -100,7 +101,7 @@ python_version = "3.13"
 strict = true
 warn_unused_configs = true
 pretty = true
-exclude = "^(build|dist)/"
+exclude = "^(build|dist|release-win)/"
 
 [[tool.mypy.overrides]]
 module = ["rich.*", "PIL.*", "pystray.*", "webview.*"]

--- a/tests/test_usage_client.py
+++ b/tests/test_usage_client.py
@@ -346,6 +346,39 @@ def test_fetch_once_prefers_complete_hook_over_claude_json_cache(
     assert outcome.snapshot.current_percent == 12
 
 
+@pytest.mark.parametrize("invalid_percentage", ["bad", True])
+def test_fetch_once_uses_claude_json_when_hook_percentage_is_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, invalid_percentage: object
+) -> None:
+    fetched_at = 1_784_144_611.575
+    status_path = tmp_path / "usage-status.json"
+    claude_json_path = tmp_path / ".claude.json"
+    monkeypatch.setattr(usage_client, "STATUS_FILE", str(status_path))
+    monkeypatch.setattr(usage_client, "LEGACY_STATUS_FILE", str(tmp_path / "legacy.json"))
+    monkeypatch.setattr(usage_client, "TT_STATUS_FILE", str(tmp_path / "tt-status.json"))
+    monkeypatch.setattr(usage_client, "CLAUDE_JSON_FILE", str(claude_json_path))
+    monkeypatch.setattr("usage_client.time.time", lambda: fetched_at + 2)
+    status_path.write_text(
+        json.dumps(
+            {
+                "_received_at_ts": fetched_at + 1,
+                "rate_limits": {
+                    "five_hour": {"used_percentage": invalid_percentage},
+                    "seven_day": {"used_percentage": 34},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_claude_json(claude_json_path, fetched_at)
+
+    outcome = asyncio.run(usage_client.ClaudeUsageClient(mock=False).fetch_once())
+
+    assert outcome.snapshot is not None
+    assert outcome.snapshot.data_source == "claude-json"
+    assert outcome.snapshot.current_percent == 3
+
+
 @pytest.mark.parametrize(
     "contents",
     ["{bad json", "{}", '{"cachedUsageUtilization": {}}'],

--- a/tests/test_usage_client.py
+++ b/tests/test_usage_client.py
@@ -325,7 +325,7 @@ def test_fetch_once_uses_claude_json_when_status_is_missing(
 
 
 @pytest.mark.parametrize("status_age", [-1.0, 1.0])
-def test_fetch_once_chooses_newest_complete_source(
+def test_fetch_once_prefers_complete_hook_over_claude_json_cache(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, status_age: float
 ) -> None:
     fetched_at = 1_784_144_611.575
@@ -342,12 +342,8 @@ def test_fetch_once_chooses_newest_complete_source(
     outcome = asyncio.run(usage_client.ClaudeUsageClient(mock=False).fetch_once())
 
     assert outcome.snapshot is not None
-    if status_age >= 0:
-        assert outcome.snapshot.data_source == "hook"
-        assert outcome.snapshot.current_percent == 12
-    else:
-        assert outcome.snapshot.data_source == "claude-json"
-        assert outcome.snapshot.current_percent == 3
+    assert outcome.snapshot.data_source == "hook"
+    assert outcome.snapshot.current_percent == 12
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -551,7 +551,7 @@ def test_build_state_reuses_history_until_fingerprint_changes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     controller = wintray._WindowsTrayController(mock=True, interval=60)
-    fingerprints = iter([(("history", 1, 10.0),), (("history", 1, 10.0),), (("history", 2, 11.0),)])
+    fingerprints = iter([(("history", 1, 10.0),), (("history", 2, 11.0),)])
     monkeypatch.setattr(
         menubar_state,
         "history_source_scan",
@@ -565,10 +565,40 @@ def test_build_state_reuses_history_until_fingerprint_changes(
         return original(scan)
 
     monkeypatch.setattr(controller, "_load_entries", counting_load_entries)
+    now = 100.0
+    monkeypatch.setattr("wintray.time.monotonic", lambda: now)
 
     controller._build_state()
     controller._build_state()
+    now += wintray.HISTORY_SCAN_CACHE_SECONDS
     controller._build_state()
+
+    assert calls == [1, 1]
+
+
+def test_history_source_scan_is_cached_between_tray_ticks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    scan = menubar_state.HistorySourceScan((("history", 1, 10.0),), (), ())
+    calls: list[int] = []
+    now = 100.0
+    monkeypatch.setattr("wintray.time.monotonic", lambda: now)
+
+    def scan_history() -> menubar_state.HistorySourceScan:
+        calls.append(1)
+        return scan
+
+    monkeypatch.setattr(
+        menubar_state,
+        "history_source_scan",
+        scan_history,
+    )
+
+    assert controller._history_source_scan() is scan
+    assert controller._history_source_scan() is scan
+    now += wintray.HISTORY_SCAN_CACHE_SECONDS
+    assert controller._history_source_scan() is scan
 
     assert calls == [1, 1]
 

--- a/usage_client.py
+++ b/usage_client.py
@@ -274,7 +274,10 @@ def _has_complete_rate_limits(data: dict[str, Any]) -> bool:
     seven = rl.get("seven_day")
     if not isinstance(five, dict) or not isinstance(seven, dict):
         return False
-    return five.get("used_percentage") is not None and seven.get("used_percentage") is not None
+    return (
+        _as_finite_float(five.get("used_percentage")) is not None
+        and _as_finite_float(seven.get("used_percentage")) is not None
+    )
 
 
 def _build_snapshot(data: dict[str, Any], *, data_source: str = "hook") -> UsageSnapshot | None:

--- a/usage_client.py
+++ b/usage_client.py
@@ -382,12 +382,12 @@ class ClaudeUsageClient:
             self._cached_path = source_path
             self._cached_mtime = mtime
 
-        status_polled_at = _as_finite_float(data.get("_received_at_ts"))
-        if claude_json_snapshot is not None and (
-            not _has_complete_rate_limits(data)
-            or status_polled_at is None
-            or status_polled_at < claude_json_snapshot.polled_at
-        ):
+        # ``.claude.json`` is Claude Code's cache, not a competing live source.
+        # In particular its fetchedAtMs can be newer than the hook timestamp while
+        # still describing a different/expired session.  A complete statusLine
+        # payload must therefore always win; use the cache only when the hook has
+        # not provided both quota windows yet.
+        if claude_json_snapshot is not None and not _has_complete_rate_limits(data):
             return self._success_outcome(claude_json_snapshot)
 
         if not _has_complete_rate_limits(data):

--- a/wintray.py
+++ b/wintray.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SLOW_POLL_INTERVAL_S = 300
+HISTORY_SCAN_CACHE_SECONDS = 30.0
 PANEL_WIDTH = 380
 WINDOWS_PANELS = (
     ("classic", "panel_default_name", "classic.html"),
@@ -476,6 +477,8 @@ class _WindowsTrayController:
         self._history_fingerprint: tuple[tuple[str, int, float], ...] | None = None
         self._cached_history: _RefreshData | None = None
         self._cached_projects: tuple[list[tuple[str, int, float | None]], ...] | None = None
+        self._history_scan: menubar_state.HistorySourceScan | None = None
+        self._history_scan_at: float | None = None
 
     def _empty_state(self) -> menubar_state.PopoverState:
         missing = menubar_state._missing_row
@@ -692,6 +695,19 @@ class _WindowsTrayController:
             error_key = "history_load_error_parse"
         return _RefreshData(entries, error_key)
 
+    def _history_source_scan(self) -> menubar_state.HistorySourceScan:
+        """Avoid recursively statting every session JSONL on each tray tick."""
+        now = time.monotonic()
+        if (
+            self._history_scan is not None
+            and self._history_scan_at is not None
+            and now - self._history_scan_at < HISTORY_SCAN_CACHE_SECONDS
+        ):
+            return self._history_scan
+        self._history_scan = menubar_state.history_source_scan()
+        self._history_scan_at = now
+        return self._history_scan
+
     def _build_state(
         self,
         *,
@@ -710,7 +726,7 @@ class _WindowsTrayController:
         agy = agy_result.projection or menubar_agy.fallback_projection(self.language)
         measure("agy_load", started_at)
         started_at = time.monotonic() if debug_timing else 0.0
-        scan = menubar_state.history_source_scan()
+        scan = self._history_source_scan()
         if menubar_state.history_cache_needs_reload(
             self._history_fingerprint,
             scan.fingerprint,


### PR DESCRIPTION
## Summary
- `usage_client.py`: a complete, fresh statusLine hook payload could be overridden by the `.claude.json` cache whenever the cache's `fetchedAtMs` looked newer, even when it described a different/expired session — so the Windows tray sometimes showed stale or wrong quota instead of the live hook data. A complete hook payload now always wins.
- `wintray.py`: `history_source_scan()` was re-stat'ing every Codex/Claude session JSONL on every tray refresh tick; added a 30s cache to cut redundant disk scans (main source of reported UI jank).
- `pyproject.toml`: excluded the local `release-win/` build staging dir from ruff/mypy so it doesn't pollute lint/type-check runs.

## Test plan
- [x] `uv run ruff check`
- [x] `uv run mypy .`
- [x] `uv run pytest -v` (754 passed, 2 skipped)
- [x] Rebuilt `usage.exe` (PyInstaller), verified `--doctor` reports `usage v0.28.7`
- [x] Verified `fetch_once()` returns `data_source=hook` with `current_percent` matching the live hook file