### PR TITLE
fix(wintray): 系統匣提示文字三處修復

### DIFF
--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -1827,9 +1827,11 @@ def test_update_alert_strips_markdown_from_release_notes(
     messages: list[tuple[str, int]] = []
     controller = wintray._WindowsTrayController(mock=True, interval=60)
     controller.language = "en"
-    monkeypatch.setattr(controller, "_message_box", lambda text, **kw: messages.append(
-        (text, kw.get("style", 0x40))
-    ) or 6)
+    def message_box(text: str, *, style: int = 0x40) -> int:
+        messages.append((text, style))
+        return 6
+
+    monkeypatch.setattr(controller, "_message_box", message_box)
     monkeypatch.setattr("wintray.update_gate.resolve_alert_choice", lambda *a: ("dismiss", {}))
 
     controller._show_update_alert(release)

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -207,8 +207,7 @@ def test_draw_tray_icon_and_tooltip(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert icon_image.size == (64, 64)
     assert wintray.build_tooltip(_state()).splitlines() == [
-        "Claude Session: 25%",
-        "Claude Weekly: 60%",
+        "Claude Session: 25% · Weekly: 60%",
         "Codex Session: 25% · Weekly: 60%",
     ]
 
@@ -223,8 +222,7 @@ def test_build_tooltip_includes_antigravity_when_visible() -> None:
     )
 
     assert wintray.build_tooltip(state).splitlines() == [
-        "Claude Session: 25%",
-        "Claude Weekly: 60%",
+        "Claude Session: 25% · Weekly: 60%",
         "Codex Session: 25% · Weekly: 60%",
         "Antigravity Session: 25% · Weekly: 60%",
     ]

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -1799,6 +1799,30 @@ def test_manual_update_check_bypasses_gates_and_keeps_windows_yes_no_prompt(
     assert opened == [release.html_url]
 
 
+def test_update_alert_strips_markdown_from_release_notes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = update_checker.ReleaseInfo(
+        version="99.0.0",
+        html_url="https://github.com/aqua5230/usage/releases/tag/v99.0.0",
+        body="### Added\n- **Faster** startup via `usage status`.",
+    )
+    messages: list[tuple[str, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.language = "en"
+    monkeypatch.setattr(controller, "_message_box", lambda text, **kw: messages.append(
+        (text, kw.get("style", 0x40))
+    ) or 6)
+    monkeypatch.setattr("wintray.update_gate.resolve_alert_choice", lambda *a: ("dismiss", {}))
+
+    controller._show_update_alert(release)
+
+    assert messages == [
+        ("New Version 99.0.0 Available\n\nAdded\n\n• Faster startup via usage status.", 0x44)
+    ]
+    assert not any(marker in messages[0][0] for marker in ("#", "**", "`"))
+
+
 def test_session_hook_toggles_run_in_background_helpers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -9,6 +9,7 @@ import threading
 import time
 from collections.abc import Callable
 from contextlib import suppress
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -206,10 +207,28 @@ def test_draw_tray_icon_and_tooltip(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert icon_image.size == (64, 64)
     assert wintray.build_tooltip(_state()).splitlines() == [
-        "Claude Session: 75%",
-        "Claude Weekly: 40%",
-        "Codex Session: 75% · Weekly: 40%",
+        "Claude Session: 25%",
+        "Claude Weekly: 60%",
+        "Codex Session: 25% · Weekly: 60%",
     ]
+
+
+def test_build_tooltip_includes_antigravity_when_visible() -> None:
+    base_state = _state()
+    state = replace(
+        base_state,
+        hide_agy=False,
+        agy_session=replace(base_state.agy_session, percent=25.0),
+        agy_weekly=replace(base_state.agy_weekly, percent=60.0),
+    )
+
+    assert wintray.build_tooltip(state).splitlines() == [
+        "Claude Session: 25%",
+        "Claude Weekly: 60%",
+        "Codex Session: 25% · Weekly: 60%",
+        "Antigravity Session: 25% · Weekly: 60%",
+    ]
+    assert "Antigravity" not in wintray.build_tooltip(_state())
 
 
 def test_windows_panels_exclude_talent_market() -> None:

--- a/wintray.py
+++ b/wintray.py
@@ -563,17 +563,25 @@ def _set_taskbar_progress(
 
 def build_tooltip(state: menubar_state.PopoverState) -> str:
     def line(name: str, row: menubar_state.QuotaRowState) -> str:
-        remaining = "--" if row.percent is None else str(max(0, round(100 - row.percent)))
-        return f"{name} {row.title}: {remaining}%"
-
-    return "\n".join(
-        (
-            line("Claude", state.claude_session),
-            line("Claude", state.claude_weekly),
-            f"{line('Codex', state.codex_session)} · "
-            f"{line('Codex', state.codex_weekly).removeprefix('Codex ')}",
+        used = (
+            "--"
+            if row.percent is None
+            else str(min(100, max(0, round(row.percent))))
         )
-    )
+        return f"{name} {row.title}: {used}%"
+
+    lines = [
+        line("Claude", state.claude_session),
+        line("Claude", state.claude_weekly),
+        f"{line('Codex', state.codex_session)} · "
+        f"{line('Codex', state.codex_weekly).removeprefix('Codex ')}",
+    ]
+    if not state.hide_agy:
+        lines.append(
+            f"{line('Antigravity', state.agy_session)} · "
+            f"{line('Antigravity', state.agy_weekly).removeprefix('Antigravity ')}"
+        )
+    return "\n".join(lines)
 
 
 def draw_tray_icon(used_percent: float | None) -> Image:

--- a/wintray.py
+++ b/wintray.py
@@ -572,8 +572,8 @@ def build_tooltip(state: menubar_state.PopoverState) -> str:
         return f"{name} {row.title}: {used}%"
 
     lines = [
-        line("Claude", state.claude_session),
-        line("Claude", state.claude_weekly),
+        f"{line('Claude', state.claude_session)} · "
+        f"{line('Claude', state.claude_weekly).removeprefix('Claude ')}",
         f"{line('Codex', state.codex_session)} · "
         f"{line('Codex', state.codex_weekly).removeprefix('Codex ')}",
     ]

--- a/wintray.py
+++ b/wintray.py
@@ -54,6 +54,7 @@ from panels.payload import _load_panel_html, _state_payload
 from prefs import _load_preferences, _save_preferences
 from pricing import calculate_cost
 from statusline_settings import _statusline_enabled, _toggle_statusline_settings
+from update_release_notes import format_release_notes
 from usage_client import ClaudeUsageClient, PollState
 from usage_lang import detect_lang
 from usage_notifications import NotificationEvent, QuotaNotifier
@@ -1650,9 +1651,8 @@ class _WindowsTrayController:
 
     def _show_update_alert(self, release: update_checker.ReleaseInfo) -> None:
         title = _t(self.language, "update_alert_title", version=release.version)
-        result = self._message_box(
-            f"{title}\n\n{release.body[:UPDATE_ALERT_BODY_LIMIT]}", style=0x44
-        )
+        body = format_release_notes(release.body, UPDATE_ALERT_BODY_LIMIT)
+        result = self._message_box(f"{title}\n\n{body}", style=0x44)
         action, preference_updates = update_gate.resolve_alert_choice(
             1000 if result == 6 else 1001,
             release.version,


### PR DESCRIPTION
## Summary
- 系統匣 tooltip 原本顯示「剩餘%」(100-已用%)，跟面板的「已用%」邏輯相反；同時完全漏掉 Antigravity 段落 → 改成顯示已用%，並在 `hide_agy=False` 時補上 Antigravity 行
- 更新通知彈窗（Windows 的系統 Yes/No 對話框）直接顯示 GitHub Release 原始 Markdown（`##`、`**`、`` ` ``），macOS 端在 0.29.28（184fb74）已修過同一個問題但沒同步到 Windows → 補接共用的 `update_release_notes.format_release_notes()`
- Claude 那兩行（Session、Weekly）原本各佔一行，跟 Codex/Antigravity 的「Session · Weekly」單行格式不一致 → 改成同樣的合併寫法

## Test plan
- [x] `pytest tests/test_wintray.py -q`（104 passed, 1 skipped）
- [x] `ruff check wintray.py tests/test_wintray.py`
- [x] `mypy wintray.py`
- [x] 本機跑 `usage` 系統匣程式實際確認提示文字與更新彈窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)