### PR TITLE
fix(build): Windows 打包補回 wintray.app 與 tui.app 的 hidden-import

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -39,11 +39,11 @@ try {
         --add-data "$(Join-Path $RepoRoot 'usage_session_resume.py');." `
         --add-data "$(Join-Path $RepoRoot 'usage_terse_mode.py');." `
         --add-data "$(Join-Path $RepoRoot 'usage_terse_reminder.py');." `
-        --hidden-import wintray `
+        --hidden-import wintray.app `
         --hidden-import pystray `
         --hidden-import webview `
         --hidden-import webview.platforms.edgechromium `
-        --hidden-import tui `
+        --hidden-import tui.app `
         --hidden-import session_hooks `
         --hidden-import setup_hook `
         --hidden-import adapters.registry `


### PR DESCRIPTION
## 問題

已發佈的 Windows 版 **v0.29.34、v0.29.35、v0.29.36 一啟動就崩潰**，任何下載者都會看到：

```
ModuleNotFoundError: No module named 'wintray.app'
...
ModuleNotFoundError: No module named 'tui.app'
```

`main.py` 的 fallback 也一起失效：wintray 匯入失敗會退回 TUI，但 `tui.app` 同樣沒被打包進去，所以直接爆在使用者臉上。

## 原因

v0.29.34 的重構（6ed1f06、0a98175）把 `wintray.py` 搬成 `wintray/app.py`、`tui.py` 搬成 `tui/app.py`，但 `scripts/build_windows.ps1` 仍以舊的頂層模組名做 hidden-import。兩個套件的 `__init__.py` 都是空的，PyInstaller 因此只收到空殼，連帶整棵 `wintray` 依賴樹（`panels.*`、`updates.*` 等）都沒被收進去。

macOS 端不受影響：`setup_app.py` 用 py2app 的 `packages` 收整個套件，重構後名稱仍然對得上。

## 驗證

以 `PyInstaller.utils.cliutils.archive_viewer -l -r` 直接檢查 exe 內含模組：

| 版本 | exe 大小 | 內含模組數 | `wintray.app` |
|---|---|---|---|
| v0.29.33（最後正常） | 9,040,464 | 1314 | —（當時仍是頂層 `wintray`，42,981 bytes） |
| v0.29.34 | — | 694 | ❌ |
| v0.29.35 | — | 695 | ❌ |
| v0.29.36 | 5,712,304 | 697 | ❌ |
| 本 PR 重新打包 | 9,105,297 | 1329 | ✅ 43,367 bytes |

修正後在 Windows 10 19045 實機啟動，系統匣圖示與面板正常，無例外對話框。

## 後續建議（本 PR 未含）

`tests/test_main.py` 只守得住「原始碼能以字串載入那些模組」，守不住「打包產物有沒有收進去」。建議在 `build_windows.ps1` 尾端加一段打包後斷言，檢查 exe 內含 `wintray.app` / `tui.app`，缺了就讓 CI 紅。

需重新發版（v0.29.37）才能修好已發佈的 Windows 版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)