### PR TITLE
ci(build): Windows 打包後斷言 exe 內含 wintray.app 與 tui.app

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -63,3 +63,15 @@ $Executable = Join-Path $OutputDir "usage.exe"
 if (-not (Test-Path $Executable -PathType Leaf)) {
     throw "PyInstaller did not produce $Executable"
 }
+
+# The exe existing is not proof it works: v0.29.34-36 shipped bundles whose
+# hidden-import names still pointed at pre-refactor top-level modules, so the
+# packages collected nothing and the app died on launch. Assert the two
+# dynamically imported entry modules are actually inside the archive.
+$RequiredModules = @('wintray.app', 'tui.app')
+$ArchiveToc = uv run --no-sync python -m PyInstaller.utils.cliutils.archive_viewer -l -r $Executable
+foreach ($Module in $RequiredModules) {
+    if (-not ($ArchiveToc | Select-String -SimpleMatch -Quiet "'$Module'")) {
+        throw "packaged exe is missing module: $Module"
+    }
+}


### PR DESCRIPTION
接續 #107。#107 修的是症狀（hidden-import 名稱），這個 PR 補的是「為什麼沒人擋下來」。

## 問題

`scripts/build_windows.ps1` 收尾只檢查 exe 檔案有沒有生出來：

```powershell
if (-not (Test-Path $Executable -PathType Leaf)) {
    throw "PyInstaller did not produce $Executable"
}
```

v0.29.34、v0.29.35、v0.29.36 三版打出的 exe 都通過了這關——檔案確實存在，只是裡面少了 `wintray.app` 與 `tui.app`，使用者一點開就是 `ModuleNotFoundError`。

`tests/test_main.py` 守的是「原始碼能不能以字串載入那些模組」，守不到打包產物的內容，所以整條路上沒有任何一關看得見這個破口。

## 做法

用 PyInstaller 自帶的 `archive_viewer` 列出封存內容，確認兩個以字串動態載入的進入點模組確實在裡面，缺任一就 `throw`。

`build_windows.ps1` 只在 `release.yml`（推 tag 時）跑，所以這段擋的是發版當下——release job 失敗、不會產出壞的 artifact。

實作上刻意用 `Select-String -Quiet` 取布林值，而不是 `if ($ArchiveToc -notmatch ...)`：`$ArchiveToc` 是字串陣列，`-notmatch` 在陣列上是過濾器而非布林值，會恆為真而永遠 throw。

## 驗證

在 Windows 10 19045 實跑兩次完整打包：

| 情境 | 結果 |
|---|---|
| 本分支（不含 #107 的修正） | `throw "packaged exe is missing module: wintray.app"`，exit code 1 ✅ 抓到 |
| 本分支 + cherry-pick #107 的修正 | 打包完成，exit code 0 ✅ 不誤報 |

## 合併順序

請在 #107 之後合併。單獨合併本 PR 而未合 #107 的話，下次發版會直接失敗——那正是預期行為，但先合 #107 比較順。

🤖 Generated with [Claude Code](https://claude.com/claude-code)