### PR TITLE
fix(build): point Windows hidden-imports at their post-refactor package paths

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -44,8 +44,8 @@ try {
         --hidden-import webview `
         --hidden-import webview.platforms.edgechromium `
         --hidden-import tui.app `
-        --hidden-import session_hooks `
-        --hidden-import setup_hook `
+        --hidden-import installer.session_hooks `
+        --hidden-import installer.setup_hook `
         --hidden-import adapters.registry `
         --hidden-import analyzer.reporter `
         --hidden-import ui.html_report `


### PR DESCRIPTION
`chore: slim the repo root` (1cc5929) moved `session_hooks.py` and `setup_hook.py` into `installer/`, but `scripts/build_windows.ps1` kept passing the bare top-level names to PyInstaller:

```powershell
        --hidden-import session_hooks `
        --hidden-import setup_hook `
```

Both modules still reached the bundle through `main.py`'s static `from installer import session_hooks, setup_hook`, so the shipped bundle was never broken. But the two flags were dead config of exactly the kind that produced the unusable v0.29.34-36 bundles, which is what the post-build assertion at `scripts/build_windows.ps1:71-79` exists to catch.

## Verification

Rebuilt on Windows 10 (19045) with Python 3.13.15 and inspected the packaged exe:

- `warn-usage.txt` reports no missing module for either name
- archive still contains `wintray.app`, `tui.app`, `installer.session_hooks`, `installer.setup_hook`
- the packaged `usage.exe` launches and spawns its `msedgewebview2.exe` child

## Wider Windows check on this branch's base

Alongside this fix I ran the full Windows surface on `5fa8796`, all green: pytest 1519 passed / 23 skipped (all macOS- or POSIX-only), `ruff check` clean, `mypy` clean across 217 files, every CLI subcommand, the statusline hook, the TUI dashboard, all 14 tray panels, and WebView2 rendering a panel with zero JS errors.

Two stale references were found and deliberately left alone:

- `scripts/check_panel_parity.py:67` falls back to reading the deleted `wintray.py`, but the `importlib.import_module("wintray.app")` above it always succeeds (every third-party import in `wintray/app.py` is lazy, so it imports on the macOS CI runner without the `windows` extra). Unreachable, and CI on `main` is green.
- `build/pyinstaller-spec/usage.spec` carries the same stale names but is regenerated by every build and is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)