### PR TITLE
fix(panels): keep a scaled panel's layout box at its natural height

### DIFF
--- a/menubar/popover.py
+++ b/menubar/popover.py
@@ -198,8 +198,10 @@ class PopoverViewController(NSViewController):
         if self.latest_state is None or self.panel is None:
             return
         scale = panel_scale(self.latest_state, self.panel)
+        _, natural_height = panel_window_state.resolve_panel_size(self.latest_state, self.panel)
         panel_id = self.panel.id
-        if self.panel_scales.get(panel_id) == scale:
+        target = (scale, natural_height)
+        if self.panel_scales.get(panel_id) == target:
             return
         view = self.content_view
         if not hasattr(view, "evaluateJavaScript_completionHandler_"):
@@ -213,11 +215,11 @@ class PopoverViewController(NSViewController):
                 and self.panel.id == panel_id
                 and self.content_view is view
             ):
-                self.panel_scales[panel_id] = scale
+                self.panel_scales[panel_id] = target
 
         view.evaluateJavaScript_completionHandler_(
             "typeof window.usageApplyPanelZoom === 'function' ? "
-            f"window.usageApplyPanelZoom({scale}) : false",
+            f"window.usageApplyPanelZoom({scale}, {natural_height}) : false",
             _completed,
         )
 

--- a/panels/dynamic_height.py
+++ b/panels/dynamic_height.py
@@ -18,9 +18,16 @@ CONTENT_HEIGHT_SCRIPT = """
   function naturalContentHeight() {
     var root = document.documentElement;
     var zoom = root.style.zoom;
+    var body = document.body;
+    // usageApplyPanelZoom expands this layout box while Chromium zoom is
+    // active. Release it as well as zoom, otherwise a subsequent measurement
+    // would report the compensated height rather than the natural content.
+    var bodyHeight = body ? body.style.height : "";
     root.style.zoom = "normal";
+    if (body) body.style.height = "";
     var wrap = document.querySelector(".wrap");
     if (!wrap) {
+      if (body) body.style.height = bodyHeight;
       root.style.zoom = zoom;
       return null;
     }
@@ -102,6 +109,7 @@ CONTENT_HEIGHT_SCRIPT = """
       floors.forEach(function(floor) {
         floor.element.style.minHeight = floor.minHeight;
       });
+      if (body) body.style.height = bodyHeight;
       root.style.zoom = zoom;
     }
   }
@@ -131,10 +139,23 @@ CONTENT_HEIGHT_SCRIPT = """
     lastPostedHeight = null;
     requestContentHeight();
   };
-  window.usageApplyPanelZoom = function(scale) {
+  window.usageApplyPanelZoom = function(scale, naturalHeight) {
     var value = Number(scale);
-    document.documentElement.style.zoom =
-      Number.isFinite(value) && value > 0 && value !== 1 ? String(value) : "normal";
+    var root = document.documentElement;
+    var body = document.body;
+    var height = Number(naturalHeight);
+    var scaled = Number.isFinite(value) && value > 0 && value !== 1;
+    root.style.zoom = scaled ? String(value) : "normal";
+    // Chromium's CSS zoom scales the paint output but leaves its layout box at
+    // the viewport height. Give that box the known natural content height so
+    // flex children are not shrunk and clipped before they are painted.
+    // naturalHeight is optional to keep pages invoked with the old one-arg
+    // signature working; a missing value simply keeps the legacy zoom-only
+    // behavior. Returning to scale 1 always removes the compensation.
+    if (body) {
+      body.style.height = scaled && Number.isFinite(height) && height > 0
+        ? String(height) + "px" : "";
+    }
     return true;
   };
   window.usageApplyState = function usageApplyStateWithDynamicHeight(state) {

--- a/tests/test_dynamic_height.py
+++ b/tests/test_dynamic_height.py
@@ -37,6 +37,10 @@ def test_script_wraps_state_application_and_measures_without_height_constraints(
     assert "lastPostedHeight = null;" in CONTENT_HEIGHT_SCRIPT
     assert 'root.style.zoom = "normal"' in CONTENT_HEIGHT_SCRIPT
     assert "window.usageApplyPanelZoom" in CONTENT_HEIGHT_SCRIPT
+    assert "function(scale, naturalHeight)" in CONTENT_HEIGHT_SCRIPT
+    assert 'body.style.height = ""' in CONTENT_HEIGHT_SCRIPT
+    assert 'String(height) + "px"' in CONTENT_HEIGHT_SCRIPT
+    assert "innerHeight /" not in CONTENT_HEIGHT_SCRIPT
     # Panels draw their edges with padding on whichever layer wraps .wrap, and
     # the viewport-based panels nest an extra padded .viewport in between, so
     # the whole ancestor chain has to be released and measured — assuming a
@@ -46,6 +50,10 @@ def test_script_wraps_state_application_and_measures_without_height_constraints(
     assert "paddingBottom" in CONTENT_HEIGHT_SCRIPT
     assert 'querySelectorAll("[data-usage-height-floor]")' in CONTENT_HEIGHT_SCRIPT
     assert 'floor.element.style.minHeight = floor.height + "px"' in CONTENT_HEIGHT_SCRIPT
+    # Measuring must release the Chromium-only height compensation before it
+    # reads the natural layout, then put it back before the next paint.
+    assert "var bodyHeight = body ? body.style.height" in CONTENT_HEIGHT_SCRIPT
+    assert "body.style.height = bodyHeight" in CONTENT_HEIGHT_SCRIPT
 
 
 def test_world_cup_declares_its_pitch_height_floor() -> None:

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -255,6 +255,11 @@ def test_apply_panel_scale_caches_only_after_successful_javascript(
     controller.content_view = view
 
     monkeypatch.setattr(menubar_popover, "panel_scale", lambda state, active_panel: 0.7785)
+    monkeypatch.setattr(
+        panel_window_state,
+        "resolve_panel_size",
+        lambda state, active_panel: (320.0, 1000.0),
+    )
     menubar_popover.PopoverViewController.applyPanelScale(controller)
     calls[-1][1](False, None)
 
@@ -263,7 +268,8 @@ def test_apply_panel_scale_caches_only_after_successful_javascript(
     menubar_popover.PopoverViewController.applyPanelScale(controller)
     calls[-1][1](True, None)
 
-    assert controller.panel_scales == {"classic": 0.7785}
+    assert controller.panel_scales == {"classic": (0.7785, 1000.0)}
+    assert "usageApplyPanelZoom(0.7785, 1000.0)" in calls[-1][0]
 
 
 def test_bar_color_thresholds() -> None:

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -456,11 +456,50 @@ def test_content_height_keeps_the_panels_natural_height(
     assert controller.panel_height() == 1000
 
 
+def test_failed_panel_zoom_does_not_resize_window_to_scaled_height(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mutations: list[tuple[str, int, int]] = []
+    zoom_ready = False
+
+    javascript: list[str] = []
+
+    def evaluate_js(code: str) -> bool:
+        javascript.append(code)
+        return zoom_ready
+
+    window = SimpleNamespace(
+        x=0,
+        y=0,
+        evaluate_js=evaluate_js,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = window
+    controller._content_height = 1000
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(
+        controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800)
+    )
+
+    controller._place_window()
+
+    assert mutations == []
+    assert "usageApplyPanelZoom(0.776, 1000)" in javascript[-1]
+
+    zoom_ready = True
+    controller._place_window()
+
+    assert mutations == [("resize", 295, 776), ("move", 693, 12)]
+
+
 def test_background_window_mutation_is_dispatched_to_ui_thread(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     main_thread_id = threading.get_ident()
     mutation_threads: list[int] = []
+    javascript_threads: list[int] = []
     scheduling_threads: list[int] = []
     scheduled_drains: list[Callable[[], None]] = []
 
@@ -468,10 +507,15 @@ def test_background_window_mutation_is_dispatched_to_ui_thread(
         scheduling_threads.append(threading.get_ident())
         scheduled_drains.append(callback)
 
+    def evaluate_js(_code: str) -> bool:
+        javascript_threads.append(threading.get_ident())
+        return True
+
     native = SimpleNamespace(InvokeRequired=True, BeginInvoke=begin_invoke)
     controller = wintray._WindowsTrayController(mock=True, interval=60)
     controller.window = SimpleNamespace(
         native=native,
+        evaluate_js=evaluate_js,
         resize=lambda _width, _height: mutation_threads.append(threading.get_ident()),
         move=lambda _x, _y: mutation_threads.append(threading.get_ident()),
     )
@@ -485,10 +529,12 @@ def test_background_window_mutation_is_dispatched_to_ui_thread(
     worker.join()
 
     assert mutation_threads == []
+    assert javascript_threads == [worker.ident]
     assert len(scheduling_threads) == 1
     assert scheduling_threads[0] != main_thread_id
     scheduled_drains.pop()()
     assert mutation_threads == [main_thread_id, main_thread_id]
+    assert javascript_threads == [worker.ident]
 
 
 def test_load_preferences_non_utf8(

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -820,38 +820,41 @@ class _WindowsTrayController:
         return self._content_height or PANEL_HEIGHTS[self.active_panel_id]
 
     def _apply_content_height(self, value: object) -> None:
-        self._dispatch_window_mutation(lambda: self._apply_content_height_on_ui_thread(value))
+        self._apply_content_height_now(value)
 
-    def _apply_content_height_on_ui_thread(self, value: object) -> None:
+    def _apply_content_height_now(self, value: object) -> None:
         if self.stopping.is_set():
             return
-        current_position = self._current_window_position()
-        work_area = self._work_area_for_point(current_position) or self._working_area()
-        maximum = (
-            float(work_area[3] - work_area[1] - 24)
-            if work_area is not None
-            else float(PANEL_HEIGHTS[self.active_panel_id])
-        )
         height = clamp_content_height(value)
         if height is None:
             return
         rounded = int(round(height))
         if rounded == self._content_height:
+            # A newly loaded panel can have the same natural height as the
+            # previous one. Its first placement may have arrived before the
+            # page installed usageApplyPanelZoom, so give that document one
+            # more chance to converge when it reports its own height.
+            if self.visible:
+                self._place_window()
             return
         self._content_height = rounded
-        self._apply_panel_zoom(fit_scale(height, maximum))
         if self.visible:
-            self._place_window_on_ui_thread()
+            self._place_window()
 
-    def _apply_panel_zoom(self, scale: float) -> None:
+    def _apply_panel_zoom(self, scale: float) -> bool:
         if self.window is not None and hasattr(self.window, "evaluate_js"):
             try:
-                self.window.evaluate_js(
+                result = self.window.evaluate_js(
                     "typeof window.usageApplyPanelZoom === 'function' && "
-                    f"window.usageApplyPanelZoom({scale})"
+                    f"window.usageApplyPanelZoom({scale}, {self.panel_height()})"
                 )
+                return result is True
             except Exception:
                 logger.exception("Unable to apply panel zoom")
+            return False
+        # Lightweight window doubles do not embed a browser. There is no DOM
+        # to scale, so geometry-only tests can proceed normally.
+        return self.window is not None
 
     def attach(self, icon: Any, window: Any) -> None:
         self.icon = icon
@@ -1003,9 +1006,23 @@ class _WindowsTrayController:
         return (max(left + 12, right - width - 12), max(top + 12, bottom - height - 12))
 
     def _place_window(self, *, force_default: bool = False) -> None:
-        self._dispatch_window_mutation(
-            lambda: self._place_window_on_ui_thread(force_default=force_default)
+        current_position = self._current_window_position()
+        work_area = self._work_area_for_point(current_position) or self._working_area()
+        maximum = (
+            float(work_area[3] - work_area[1] - 24)
+            if work_area is not None
+            else float(PANEL_HEIGHTS[self.active_panel_id])
         )
+        scale = fit_scale(self.panel_height(), maximum)
+        zoom_applied = self._apply_panel_zoom(scale)
+        if scale < 1.0 and not zoom_applied:
+            return
+        if force_default:
+            self._dispatch_window_mutation(
+                lambda: self._place_window_on_ui_thread(force_default=True)
+            )
+        else:
+            self._dispatch_window_mutation(self._place_window_on_ui_thread)
 
     def _place_window_on_ui_thread(self, *, force_default: bool = False) -> None:
         if self.window is None or self.stopping.is_set():
@@ -1034,7 +1051,6 @@ class _WindowsTrayController:
         fitted_width, fitted_height, scale = fit_panel_size(PANEL_WIDTH, natural_height, maximum)
         width = int(round(fitted_width))
         height = int(round(fitted_height))
-        self._apply_panel_zoom(scale)
         self.window.resize(width, height)
         position = anchor if anchor is not None else self._default_window_position(
             work_area, width, height


### PR DESCRIPTION
## 問題

面板高於可用螢幕時會縮放以塞進畫面,但 Windows 上仍然缺底部內容:**每張卡片被裁掉的量都不一樣**,footer 下方還多出一條空白。兩個獨立的缺陷疊在一起。

## 缺陷一:zoom 呼叫在 UI 執行緒上自鎖

`_apply_panel_zoom` 原本在 `_place_window_on_ui_thread` 裡執行,等於在 WinForms UI 執行緒上呼叫 `window.evaluate_js`。pywebview 會同步等待 WebView2 的 `ExecuteScriptAsync` 完成,而該完成事件又被派回同一條執行緒——呼叫永遠不返回。

活體追蹤:

```
修正前:_apply_panel_zoom ENTER InvokeRequired=False → 沒有對應的 EXIT
修正後:_apply_panel_zoom ENTER InvokeRequired=True  → 3ms EXIT returned=True
```

現在改為在呼叫端(背景執行緒)解析並套用縮放,只把 resize/move 派給 UI 執行緒;文件端沒確認縮放成功就不縮小視窗。

## 缺陷二:Chromium 的 CSS zoom 不放大版面空間

`zoom` 只縮小繪製結果,版面框仍維持視窗高度,內容因此還是照未縮放的尺寸排版。`.wrap` 的子層是 `flex: 0 1 auto` 且 `.card` / `.footer` 都 `overflow: hidden`,於是全部被等比壓縮、各自裁掉自己的內容;縮小後的繪製結果又比視窗矮 89px。

WebView2 實測(scale 0.912848,自然高度 1113 塞進 1016):

| 卡片 | 修前版面高 | 內容需要 | 被裁 |
|---|---:|---:|---:|
| claude | 141 | 182 | 41 |
| codex | 168 | 182 | 14 |
| agy | 168 | 182 | 14 |
| grok | 92 | 116 | 24 |
| projects | 159 | 208 | 49 |
| footer | 131 | 158 | 27 |

WebKit 在 zoom 下會連版面框一起放大,所以 macOS 不受影響。

## 修法

`usageApplyPanelZoom` 改為同時接收自然高度,先把 body 撐開到該高度再套用 zoom,讓 flex 子層依照真正需要的空間排版。兩個殼層各自傳入它已知的高度——Windows 用 `panel_height()`,macOS 用 `resolve_panel_size()`——**不使用 `window.innerHeight / scale`**,那在 WebKit 上會雙重補償。macOS 端快取改成 `(scale, height)`,確保高度變動但比例相同時仍會重新套用。`naturalContentHeight()` 量測時會連同 zoom 一起解除補償,避免量測值逐次放大。

## 驗證

WebView2 重新量測:body 高度等於視窗(**底部留白 0**),每張卡片的版面高度都覆蓋其內容——claude 184/182、grok 118/116、projects 209/208、footer 159/158,**裁切卡片 0 張**。

- 全套 1554 passed
- ruff / mypy / check_file_size.py 全綠
- 抽掉三個原始碼修正 → 3 個測試轉紅;裝回 → 全綠

macOS 專屬檢查(`check_panel_parity.py`、`tests/test_menubar.py`)需 PyObjC,在 Windows 無法執行,交由 CI 驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es6czYMZ99nN8ma4QxZ98V