### PR TITLE
fix(wintray): fold Grok CLI's tokens into Windows' today cost too

### DIFF
--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -1399,6 +1399,52 @@ def test_build_state_reuses_history_until_fingerprint_changes(
     assert calls == [1, 1]
 
 
+def test_load_entries_includes_grok_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    controller = wintray._WindowsTrayController(mock=False, interval=60)
+    scan = menubar_state.HistorySourceScan((), (), ())
+    claude_entry = SimpleNamespace(source="claude")
+    codex_entry = SimpleNamespace(source="codex")
+    grok_entry = SimpleNamespace(source="grok")
+    monkeypatch.setattr(wintray, "load_entries", lambda **_kwargs: [claude_entry])
+    monkeypatch.setattr(codex_loader, "load_entries", lambda **_kwargs: [codex_entry])
+    monkeypatch.setattr("wintray.app.grok_loader.load_entries", lambda **_kwargs: [grok_entry])
+
+    result = controller._load_entries(scan)
+
+    assert result.entries == [claude_entry, codex_entry, grok_entry]
+    assert result.history_error_key is None
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_error_key"),
+    [
+        (OSError("Grok log unavailable"), "history_load_error_file"),
+        (ValueError("Grok log malformed"), "history_load_error_parse"),
+    ],
+)
+def test_load_entries_keeps_other_entries_when_grok_load_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_error_key: str,
+) -> None:
+    controller = wintray._WindowsTrayController(mock=False, interval=60)
+    scan = menubar_state.HistorySourceScan((), (), ())
+    claude_entry = SimpleNamespace(source="claude")
+    codex_entry = SimpleNamespace(source="codex")
+    monkeypatch.setattr(wintray, "load_entries", lambda **_kwargs: [claude_entry])
+    monkeypatch.setattr(codex_loader, "load_entries", lambda **_kwargs: [codex_entry])
+
+    def fail_grok_load(**_kwargs: object) -> list[object]:
+        raise error
+
+    monkeypatch.setattr("wintray.app.grok_loader.load_entries", fail_grok_load)
+
+    result = controller._load_entries(scan)
+
+    assert result.entries == [claude_entry, codex_entry]
+    assert result.history_error_key == expected_error_key
+
+
 def test_build_state_reloads_cached_projects_when_local_date_changes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -30,7 +30,7 @@ import service_status
 import usage_diagnosis_snapshot
 from i18n import _t
 from installer.statusline_settings import _statusline_enabled, _toggle_statusline_settings
-from loaders import codex_loader
+from loaders import codex_loader, grok_loader
 from loaders.history_loader import UsageEntry, load_entries
 from menubar import agy as menubar_agy
 from menubar import grok as menubar_grok
@@ -1242,6 +1242,12 @@ class _WindowsTrayController:
             error_key = "history_load_error_parse"
         try:
             entries.extend(codex_loader.load_entries(hours_back=0, jsonl_paths=scan.codex_paths))
+        except OSError:
+            error_key = "history_load_error_file"
+        except (ValueError, KeyError, TypeError):
+            error_key = "history_load_error_parse"
+        try:
+            entries.extend(grok_loader.load_entries(hours_back=0))
         except OSError:
             error_key = "history_load_error_file"
         except (ValueError, KeyError, TypeError):


### PR DESCRIPTION
## 問題

`5463cd3 feat: fold Grok CLI's per-request tokens into today's cost/spend` 讓 Grok CLI 的用量計入「今日花費/token 總計」與專案列表,但**只接了 macOS**:

- macOS:`menubar/state.py` 的 `app_load_history_entries()` 有呼叫 `grok_loader.load_entries()`
- Windows:`_WindowsTrayController._load_entries()` 只讀 Claude 與 Codex

結果是每一筆 Grok 的用量在 Windows 的今日花費與專案列表裡都不存在。在開發機上實測,今天有 **10 筆** Grok 記錄是系統匣完全沒看到的。

## 為什麼只缺這一段

指紋那半邊本來就是共用的:`_history_file_sources()` 已列入 `GROK_LOG_PATH`,Windows 透過 `menubar_state.history_source_scan()` 走同一條路,所以只有 Grok 活動的 session 已經能正確讓快取失效。**缺的只有載入。**

## 修法

`grok_loader.load_entries()` 沒有 `jsonl_paths` 參數——它直接讀 `GROK_LOG_PATH`,檔案不存在時自己 no-op——因此呼叫方式沿用相鄰兩個 loader 完全相同的 try/except 形狀,確保 Grok 讀取失敗時不會把已經收集到的 entries 丟掉。

## 驗證

對真實 log 實測:`_load_entries()` 現在回傳 2381 筆,其中 **10 筆是 Grok**,與直接呼叫 `grok_loader` 的筆數吻合。

- 全套 1556 passed
- ruff / mypy / check_file_size.py 全綠
- 抽掉 `wintray/app.py` 的修正 → 3 個新測試轉紅;裝回 → 全綠

新增測試涵蓋:Grok entries 正常併入、Grok 丟 `OSError` 與丟 `ValueError` 時仍保留 Claude/Codex 的 entries 並設出正確的 error key。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es6czYMZ99nN8ma4QxZ98V