### PR TITLE
fix(test): 狀態列測試要隔離偏好檔，別讀到開發機的更新提示

### DIFF
--- a/tests/test_usage_statusline.py
+++ b/tests/test_usage_statusline.py
@@ -147,14 +147,20 @@ def test_windows_output_tolerates_replaced_streams(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.fixture(autouse=True)
-def _isolate_context_burn_file(
+def _isolate_context_burn_and_preferences_files(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """Isolate the context-burn and preferences files for each test."""
     monkeypatch.setattr(
         usage_statusline,
         "CONTEXT_BURN_FILE",
         str(tmp_path / "usage-context-burn.json"),
+    )
+    monkeypatch.setattr(
+        usage_statusline,
+        "PREFERENCES_FILE",
+        str(tmp_path / "usage-preferences.json"),
     )
 
 


### PR DESCRIPTION
## 問題

`tests/test_usage_statusline.py` 的 autouse fixture 只隔離 `CONTEXT_BURN_FILE`，沒有隔離 `PREFERENCES_FILE`。

同一個檔案裡的 `test_render_omits_prompt_cache_when_not_observed`（兩個參數化案例）會呼叫 `render()`，而 `render()` 走 `_read_update_hint()`（`usage_statusline.py:279`）讀真實的 `~/.claude/usage-preferences.json`。開發機上只要那個檔記著有新版可用，輸出就會多一段更新提示：

```
- ...mOpus 5[0m
+ ...mOpus 5[0m [38;5;240m|[0m [36m🆕 v0.30.7 available[0m
```

斷言的乾淨字串因此對不上。CI 是乾淨環境沒有那個偏好檔，所以上游一直是綠的，這個失敗只在開發機重現。

## 修法

把 `PREFERENCES_FILE` 一併加進那個 autouse fixture，指向 `tmp_path` 底下不存在的檔——`_read_update_hint()` 開檔失敗就回 `None`，等同「沒有可用更新」。fixture 名稱與 docstring 一併調整成涵蓋兩個檔案。

在函式內手動 `monkeypatch` `PREFERENCES_FILE` 的那些 update-hint 測試（7 處）會覆蓋這個 fixture，行為不變。

`usage_statusline_agy.py` 與 `usage_statusline_grok.py` 都沒有更新提示邏輯，不需要同樣處理，因此改動限在這一個測試檔，不動 `tests/conftest.py`。

## 驗證

- `pytest tests/test_usage_statusline.py -q` → 53 passed, 1 skipped
- 完整套件（Windows 11 / Python 3.13）→ **1674 passed, 24 skipped, 0 failed**（修正前同一台是 2 failed）
- `ruff check` / `mypy` 皆通過
