### PR TITLE
fix(tui): register Antigravity loader in interactive dashboard

### DIFF
--- a/tests/test_usage_cli.py
+++ b/tests/test_usage_cli.py
@@ -102,6 +102,32 @@ def test_recent_titles_section_tolerates_missing_key() -> None:
     ) == ""
 
 
+def test_every_detectable_agent_has_a_dashboard_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dashboard 的 Antigravity 分頁曾渲染成 "No data"：detect_agents() 有偵測到
+    agy，但 usage_cli.AGENT_LOADERS 漏了 "antigravity"，_load_entries() 查不到
+    loader 就回空列表。此測試模擬三個 adapter 全部偵測成功，確保 registry 能
+    偵測到的每個 agent 在 dashboard 與 reporter 的 AGENT_LOADERS 都接上 loader。"""
+    all_agents = [
+        AgentInfo("claude-code", "Claude Code", "~/.claude", True),
+        AgentInfo("codex", "Codex", "~/.codex", True),
+        AgentInfo("antigravity", "Antigravity", "~/.gemini/antigravity-cli/conversations", True),
+    ]
+    monkeypatch.setattr(usage_cli, "detect_agents", lambda: all_agents)
+
+    detected_ids = {agent.id for agent in usage_cli.detect_agents()}
+    reporter = import_module("analyzer.reporter")
+    assert detected_ids <= set(usage_cli.AGENT_LOADERS), (
+        f"agents detected but missing from usage_cli.AGENT_LOADERS: "
+        f"{sorted(detected_ids - set(usage_cli.AGENT_LOADERS))}"
+    )
+    assert detected_ids <= set(reporter.AGENT_LOADERS), (
+        f"agents detected but missing from reporter.AGENT_LOADERS: "
+        f"{sorted(detected_ids - set(reporter.AGENT_LOADERS))}"
+    )
+
+
 def test_recent_titles_section_masks_and_escapes_each_title() -> None:
     rendered = html_report._render_recent_titles_section(
         {"persona": {"recent_titles": ["Fix <table>", "Review & ship"]}},

--- a/usage_cli.py
+++ b/usage_cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from loaders import codex_loader
-from adapters import claude, codex
+from adapters import agy, claude, codex
 from adapters.rate_limits import load_rate_limits as load_claude_rate_limits
 from adapters.registry import detect_agents
 from adapters.types import AgentInfo, RateLimits
@@ -29,7 +29,9 @@ from ui.tables import (
 )
 
 AGENT_ALIASES = {"claude": "claude-code", "codex": "codex"}
-AGENT_LOADERS = {"claude-code": claude, "codex": codex}
+# 「antigravity」要跟 analyzer/reporter.py 的 AGENT_LOADERS 同步——漏了它，
+# 互動式 dashboard 的 Antigravity 分頁會渲染成 "No data"（report 指令卻有資料）。
+AGENT_LOADERS = {"claude-code": claude, "codex": codex, "antigravity": agy}
 
 
 def _load_codex_rate_limits() -> RateLimits | None:


### PR DESCRIPTION
## 問題

互動式 dashboard（`usage dashboard`）切到 **Antigravity 分頁**時永遠顯示 `No data`，即使 `~/.gemini/antigravity-cli/conversations/` 有大量對話資料、`usage report` 也看得到 Antigravity 用量。

**重現**：macOS 15 + agy CLI 已登入 → `uvx usage-cli dashboard` → ← → 切到 Antigravity 分頁 → `No data`。

## 根因

registry 能偵測到 Antigravity（所以分頁會出現），但 `usage_cli.py` 的 `AGENT_LOADERS` 只註冊了 `claude-code` 和 `codex`：

```python
AGENT_LOADERS = {"claude-code": claude, "codex": codex}   # 漏了 "antigravity"
```

`_load_entries("antigravity")` 查不到 loader → 回空列表 → dashboard 渲染 `No data`。

而 `analyzer/reporter.py` 的同名 `AGENT_LOADERS` **有** `"antigravity": agy`——這解釋了為什麼 report 指令有資料、dashboard 卻沒有。兩份 map 只同步了一半。

## 修正

```python
from adapters import agy, claude, codex
AGENT_LOADERS = {"claude-code": claude, "codex": codex, "antigravity": agy}
```

並新增一條回歸測試 `test_every_detectable_agent_has_a_dashboard_loader`：模擬三個 adapter 全部偵測成功，斷言每個偵測到的 agent id 在 `usage_cli.AGENT_LOADERS` 與 `reporter.AGENT_LOADERS` 都有 loader，確保之後新增 adapter 時不會再漏接。

## 驗證

- `uv run pytest`：1922 passed（含新測試），5 skipped（平台限定）
- `uv run ruff check`：clean
- `uv run mypy usage_cli.py tests/test_usage_cli.py`：clean
- 本機實測 `_build_agent_data("antigravity", ...)` 回 13 天 daily 統計 / 146 sessions（原本回 `None`）