### PR TITLE
fix(wintray): 高 DPI 螢幕的面板位置、跨螢幕記憶與底部裁切

### DIFF
--- a/panels/panel_scale.py
+++ b/panels/panel_scale.py
@@ -9,8 +9,10 @@ from typing import cast
 MIN_PANEL_SCALE = 0.6
 
 
-def fit_scale(natural_height: object, maximum: object) -> float:
-    """Ratio that fits natural_height into maximum, never below MIN_PANEL_SCALE."""
+def fit_scale(
+    natural_height: object, maximum: object, minimum_scale: float = MIN_PANEL_SCALE
+) -> float:
+    """Ratio that fits natural_height into maximum, never below minimum_scale."""
     if (
         isinstance(natural_height, bool)
         or isinstance(maximum, bool)
@@ -24,14 +26,17 @@ def fit_scale(natural_height: object, maximum: object) -> float:
         return 1.0
     if natural <= available:
         return 1.0
-    return max(MIN_PANEL_SCALE, available / natural)
+    return max(minimum_scale, available / natural)
 
 
 def fit_panel_size(
-    natural_width: object, natural_height: object, maximum: object
+    natural_width: object,
+    natural_height: object,
+    maximum: object,
+    minimum_scale: float = MIN_PANEL_SCALE,
 ) -> tuple[float, float, float]:
-    """Return (width, height, scale) fitted into maximum, height never exceeding it."""
-    scale = fit_scale(natural_height, maximum)
+    """Return (width, height, scale) fitted into maximum with a specified minimum scale."""
+    scale = fit_scale(natural_height, maximum, minimum_scale)
     if (
         isinstance(natural_width, bool)
         or not isinstance(natural_width, int | float)

--- a/tests/test_panel_scale.py
+++ b/tests/test_panel_scale.py
@@ -29,6 +29,16 @@ def test_fit_scale(natural_height: object, maximum: object, expected: float) -> 
     assert fit_scale(natural_height, maximum) == expected
 
 
+def test_fit_scale_uses_supplied_minimum_for_high_dpi_panel() -> None:
+    minimum_scale = 0.6 / 2.25
+    assert fit_scale(1064.0, 535.0, minimum_scale=minimum_scale) == 535.0 / 1064.0
+
+
+def test_fit_scale_respects_supplied_minimum() -> None:
+    minimum_scale = 0.6 / 2.25
+    assert fit_scale(4000.0, 535.0, minimum_scale=minimum_scale) == minimum_scale
+
+
 @pytest.mark.parametrize(
     (
         "natural_width",
@@ -70,3 +80,11 @@ def test_fit_panel_size(
         assert width == expected_width
     assert height == expected_height
     assert scale == expected_scale
+
+
+def test_fit_panel_size_uses_supplied_minimum_for_high_dpi_panel() -> None:
+    minimum_scale = 0.6 / 2.25
+    width, height, scale = fit_panel_size(380.0, 1064.0, 535.0, minimum_scale)
+    assert height == 535.0
+    assert scale == 535.0 / 1064.0
+    assert width == 380.0 * scale

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -382,6 +382,102 @@ def test_panel_position_is_clamped_and_persisted_on_hide(
     assert prefs._load_preferences()["usage.windowPosition"] == {"x": 123, "y": 234}
 
 
+def test_panel_position_is_saved_as_native_physical_pixels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        native=SimpleNamespace(Left=2520, Top=27), x=1120, y=12, hide=lambda: None
+    )
+    controller.visible = True
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller.show_panel()
+
+    assert prefs._load_preferences()["usage.windowPosition"] == {"x": 2520, "y": 27}
+
+
+def test_panel_position_falls_back_to_scaled_logical_pixels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(x=1120, y=12, hide=lambda: None)
+    controller.visible = True
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller.show_panel()
+
+    assert prefs._load_preferences()["usage.windowPosition"] == {"x": 2520, "y": 27}
+
+
+def test_physical_saved_position_returns_to_secondary_screen_after_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    preferences_path.write_text(
+        json.dumps({"usage.windowPosition": {"x": 2520, "y": 27}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    screens = [
+        SimpleNamespace(
+            x=0, y=0, width=1920, height=1080,
+            frame=SimpleNamespace(Left=0, Top=0, Right=1920, Bottom=1040), scale=1.0,
+        ),
+        SimpleNamespace(
+            x=1920, y=0, width=2560, height=1440,
+            frame=SimpleNamespace(Left=1920, Top=0, Right=4480, Bottom=1258), scale=1.0,
+        ),
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    moves: list[tuple[int, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0, y=0, resize=lambda *_args: None, move=lambda x, y: moves.append((x, y))
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 1.0)
+
+    controller._place_window()
+
+    assert moves == [(2520, 27)]
+
+
+def test_physical_saved_position_uses_current_secondary_dpi_scale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    preferences_path.write_text(
+        json.dumps({"usage.windowPosition": {"x": 2520, "y": 27}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    screens = [
+        SimpleNamespace(
+            x=0, y=0, width=1920, height=1080,
+            frame=SimpleNamespace(Left=0, Top=0, Right=1920, Bottom=1040), scale=1.0,
+        ),
+        SimpleNamespace(
+            x=1920, y=0, width=2560, height=1440,
+            frame=SimpleNamespace(Left=1920, Top=0, Right=4480, Bottom=1258), scale=1.0,
+        ),
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    moves: list[tuple[int, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0, y=0, resize=lambda *_args: None, move=lambda x, y: moves.append((x, y))
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller._place_window()
+
+    assert moves == [(1120, 12)]
+
+
 def test_dpi_scaled_monitor_placement_uses_logical_coordinates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -480,7 +576,7 @@ def test_physical_dpi_scaled_saved_position_is_clamped_to_logical_screen(
 
     controller._place_window()
 
-    assert moves == [(1144, 404)]
+    assert moves == [(1144, 358)]
 
 
 def test_physical_dpi_scaled_screens_use_logical_height_for_panel_zoom(

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -421,6 +421,106 @@ def test_dpi_scaled_monitor_placement_uses_logical_coordinates(
     assert mutations == [("resize", 380, 400), ("move", 2424, 268)]
 
 
+def test_physical_dpi_scaled_screens_are_converted_to_logical_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=3840,
+            height=2160,
+            frame=SimpleNamespace(Left=0, Top=0, Right=3840, Bottom=2040),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    mutations: list[tuple[str, int, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.5)
+
+    controller._place_window()
+
+    assert mutations == [("resize", 380, 400), ("move", 1144, 404)]
+
+
+def test_physical_dpi_scaled_saved_position_is_clamped_to_logical_screen(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    preferences_path.write_text(
+        json.dumps({"usage.windowPosition": {"x": 3448, "y": 896}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=3840,
+            height=2160,
+            frame=SimpleNamespace(Left=0, Top=0, Right=3840, Bottom=2040),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    moves: list[tuple[int, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0, y=0, resize=lambda *_args: None, move=lambda x, y: moves.append((x, y))
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.5)
+
+    controller._place_window()
+
+    assert moves == [(1144, 404)]
+
+
+def test_physical_dpi_scaled_screens_use_logical_height_for_panel_zoom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=3840,
+            height=2160,
+            frame=SimpleNamespace(Left=0, Top=0, Right=3840, Bottom=2040),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    javascript: list[str] = []
+    mutations: list[tuple[str, int, int]] = []
+
+    def evaluate_js(code: str) -> bool:
+        javascript.append(code)
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        evaluate_js=evaluate_js,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller._content_height = 1000
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.5)
+
+    controller._place_window()
+
+    assert "usageApplyPanelZoom(0.792, 1000)" in javascript[-1]
+    assert mutations[0] == ("resize", 301, 792)
+
+
 def test_content_height_keeps_the_panels_natural_height(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1006,6 +1106,72 @@ def test_show_panel_places_window_before_showing(
 
     assert controller.visible is True
     assert calls == ["place", "show", "inject:True", "refresh"]
+
+
+def test_show_panel_queues_show_after_placement_on_ui_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callbacks: list[Callable[[], None]] = []
+    calls: list[str] = []
+    native = SimpleNamespace(
+        Handle=SimpleNamespace(ToInt32=lambda: 1),
+        InvokeRequired=True,
+        BeginInvoke=lambda callback: callbacks.append(callback),
+    )
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        native=native,
+        x=0,
+        y=0,
+        resize=lambda *_args: calls.append("resize"),
+        move=lambda *_args: calls.append("move"),
+        show=lambda: calls.append("show"),
+    )
+    monkeypatch.setitem(sys.modules, "System", SimpleNamespace(Action=lambda callback: callback))
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: None)
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800))
+    monkeypatch.setattr(controller, "inject_state", lambda *, force=False: None)
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+
+    controller.show_panel()
+
+    assert calls == []
+    callbacks.pop()()
+    assert calls == ["resize", "move", "show"]
+
+
+def test_queued_show_panel_does_not_show_after_being_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callbacks: list[Callable[[], None]] = []
+    calls: list[str] = []
+    native = SimpleNamespace(
+        Handle=SimpleNamespace(ToInt32=lambda: 1),
+        InvokeRequired=True,
+        BeginInvoke=lambda callback: callbacks.append(callback),
+    )
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        native=native,
+        x=0,
+        y=0,
+        resize=lambda *_args: calls.append("resize"),
+        move=lambda *_args: calls.append("move"),
+        show=lambda: calls.append("show"),
+    )
+    monkeypatch.setitem(sys.modules, "System", SimpleNamespace(Action=lambda callback: callback))
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: None)
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800))
+    monkeypatch.setattr(controller, "inject_state", lambda *, force=False: None)
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+
+    controller.show_panel()
+    controller.visible = False
+    callbacks.pop()()
+
+    assert calls == ["resize", "move"]
 
 
 def test_attach_schedules_startup_maintenance_after_tray_is_visible(

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -617,6 +617,80 @@ def test_physical_dpi_scaled_screens_use_logical_height_for_panel_zoom(
     assert mutations[0] == ("resize", 301, 792)
 
 
+def test_high_dpi_panel_zoom_can_fit_below_css_legibility_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=2560,
+            height=1440,
+            frame=SimpleNamespace(Left=0, Top=0, Right=2560, Bottom=1258),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    javascript: list[str] = []
+    mutations: list[tuple[str, int, int]] = []
+
+    def evaluate_js(code: str) -> bool:
+        javascript.append(code)
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        evaluate_js=evaluate_js,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda *_args: None,
+    )
+    controller._content_height = 1064
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller._place_window()
+
+    assert "usageApplyPanelZoom(0.5028195488721805, 1064)" in javascript[-1]
+    assert mutations[0] == ("resize", 191, 535)
+
+
+def test_standard_dpi_panel_zoom_keeps_css_legibility_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=1920,
+            height=1080,
+            frame=SimpleNamespace(Left=0, Top=0, Right=1920, Bottom=560),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    javascript: list[str] = []
+
+    def evaluate_js(code: str) -> bool:
+        javascript.append(code)
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        evaluate_js=evaluate_js,
+        resize=lambda *_args: None,
+        move=lambda *_args: None,
+    )
+    controller._content_height = 1064
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 1.0)
+
+    controller._place_window()
+
+    assert "usageApplyPanelZoom(0.6, 1064)" in javascript[-1]
+
+
 def test_content_height_keeps_the_panels_natural_height(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -49,7 +49,7 @@ from menubar.prefs import (
     _window_keeper_enabled,
 )
 from panels.dynamic_height import clamp_content_height, inject_content_height_script
-from panels.panel_scale import fit_panel_size, fit_scale
+from panels.panel_scale import MIN_PANEL_SCALE, fit_panel_size, fit_scale
 from panels.payload import _load_panel_html, _state_payload
 from prefs import _load_preferences, _save_preferences
 from pricing import calculate_cost
@@ -1072,6 +1072,10 @@ class _WindowsTrayController:
         left, top, right, bottom = work_area
         return (max(left + 12, right - width - 12), max(top + 12, bottom - height - 12))
 
+    # The legibility floor uses physical pixels: CSS zoom times window DPI scale.
+    def _panel_minimum_scale(self) -> float:
+        return MIN_PANEL_SCALE / (self._window_dpi_scale() or 1.0)
+
     def _place_window(self, *, force_default: bool = False) -> None:
         current_position = self._current_window_position()
         work_area = self._work_area_for_point(current_position) or self._working_area()
@@ -1080,7 +1084,7 @@ class _WindowsTrayController:
             if work_area is not None
             else float(PANEL_HEIGHTS[self.active_panel_id])
         )
-        scale = fit_scale(self.panel_height(), maximum)
+        scale = fit_scale(self.panel_height(), maximum, self._panel_minimum_scale())
         zoom_applied = self._apply_panel_zoom(scale)
         if scale < 1.0 and not zoom_applied:
             return
@@ -1115,7 +1119,9 @@ class _WindowsTrayController:
         left, top, right, bottom = work_area
         maximum = float(bottom - top - 24)
         natural_height = self.panel_height()
-        fitted_width, fitted_height, scale = fit_panel_size(PANEL_WIDTH, natural_height, maximum)
+        fitted_width, fitted_height, scale = fit_panel_size(
+            PANEL_WIDTH, natural_height, maximum, self._panel_minimum_scale()
+        )
         width = int(round(fitted_width))
         height = int(round(fitted_height))
         self.window.resize(width, height)

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -925,8 +925,61 @@ class _WindowsTrayController:
             bounds = self._screen_rectangle(screen)
             work_area = self._screen_rectangle(getattr(screen, "frame", None)) or bounds
             if bounds is not None and work_area is not None:
-                result.append((bounds, work_area))
-        return result
+                result.append((bounds, work_area, getattr(screen, "scale", None)))
+
+        primary = next(
+            (
+                screen
+                for screen in result
+                if screen[0][0] <= 0 < screen[0][2] and screen[0][1] <= 0 < screen[0][3]
+            ),
+            result[0] if result else None,
+        )
+        window_scale = self._window_dpi_scale()
+        if (
+            primary is not None
+            and primary[2] == 1.0
+            and window_scale is not None
+            and window_scale != 1.0
+        ):
+            # pywebview 6.2.1 WinForms reports physical pixels while labeling scale as 1.
+            def scale_rectangle(
+                rectangle: tuple[int, int, int, int],
+            ) -> tuple[int, int, int, int]:
+                return (
+                    int(round(rectangle[0] / window_scale)),
+                    int(round(rectangle[1] / window_scale)),
+                    int(round(rectangle[2] / window_scale)),
+                    int(round(rectangle[3] / window_scale)),
+                )
+
+            return [
+                (
+                    scale_rectangle(bounds),
+                    scale_rectangle(work_area),
+                )
+                for bounds, work_area, _scale in result
+            ]
+        return [(bounds, work_area) for bounds, work_area, _scale in result]
+
+    def _window_dpi_scale(self) -> float | None:
+        if os.name != "nt":
+            return None
+        try:
+            library_name = "windll"
+            windll: Any = getattr(ctypes, library_name)
+            user32 = windll.user32
+            native = self.window.native
+            handle = native.Handle
+            to_int32 = getattr(handle, "ToInt32", None)
+            hwnd = to_int32() if callable(to_int32) else int(handle)
+            dpi = int(user32.GetDpiForWindow(hwnd))
+        except Exception:
+            try:
+                dpi = int(user32.GetDpiForSystem())
+            except Exception:
+                return None
+        return dpi / 96.0 if dpi > 0 else None
 
     def _working_area(self) -> tuple[int, int, int, int] | None:
         """Return the primary monitor work area in pywebview logical pixels."""
@@ -1461,10 +1514,14 @@ class _WindowsTrayController:
             return
         self.visible = True
         self._place_window()
-        self.window.show()
+        self._dispatch_window_mutation(self._show_panel_on_ui_thread)
         self._update_taskbar_progress(self.latest_state.claude_session.percent)
         self.inject_state(force=True)
         self.refresh()
+
+    def _show_panel_on_ui_thread(self) -> None:
+        if self.visible and not self.stopping.is_set() and self.window is not None:
+            self.window.show()
 
     def _activate_panel(self) -> None:
         """Show or foreground the existing tray panel without toggling it closed."""

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -1021,7 +1021,8 @@ class _WindowsTrayController:
             return None
         if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
             return None
-        return (int(x), int(y))
+        scale = self._window_dpi_scale() or 1.0
+        return (int(round(x / scale)), int(round(y / scale)))
 
     def _current_window_position(self) -> tuple[int, int] | None:
         if self.window is None:
@@ -1035,6 +1036,24 @@ class _WindowsTrayController:
         if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
             return None
         return (int(x), int(y))
+
+    def _physical_window_position(self) -> tuple[int, int] | None:
+        if self.window is None:
+            return None
+        try:
+            native = self.window.native
+            x, y = native.Left, native.Top
+        except Exception:
+            x = y = None
+        if not isinstance(x, bool) and not isinstance(y, bool) and isinstance(
+            x, int | float
+        ) and isinstance(y, int | float):
+            return (int(round(x)), int(round(y)))
+        position = self._current_window_position()
+        if position is None:
+            return None
+        scale = self._window_dpi_scale() or 1.0
+        return (int(round(position[0] * scale)), int(round(position[1] * scale)))
 
     @staticmethod
     def _clamp_window_position(
@@ -1164,7 +1183,8 @@ class _WindowsTrayController:
                     logger.warning("Window mutation failed", exc_info=True)
 
     def _save_window_position(self) -> None:
-        position = self._current_window_position()
+        # Logical coordinates are tied to the window's current monitor DPI.
+        position = self._physical_window_position()
         if position is None:
             return
         preferences = _load_preferences()


### PR DESCRIPTION
## Summary
Three Windows high-DPI fixes for the tray panel, found while fixing #130 and verified on real hardware. (Previously split as #134 and #135, which were stacked on this branch; folded in so everything lands on `main` with full CI.)

### 1. Panel placed off-screen at high scaling — 4cd0138
pywebview 6.2.1's WinForms `get_screens()` returns `Screen.Bounds` / `WorkingArea` in physical pixels but labels `scale` as 1.0, while `move()` / `resize()` multiply their input by the window's DPI (`GetDpiForWindow / 96`). At 250% on 3840x2160 the default position came out as x = 3840 − 380 − 12 = 3448 — the exact left edge in the report — and `move()` scaled it again. `_save_window_position()` persisted that value, so relaunching reproduced it.

- `_logical_screens()` converts every screen rectangle back to pywebview logical pixels using the panel window's own DPI (the same factor `move()`/`resize()` apply), falling back to `GetDpiForSystem()` without a window handle. It only converts when the primary screen reports `scale == 1.0` while the window DPI is not 96, so a future pywebview returning logical coordinates is not double-converted.
- `show_panel()` queues `window.show()` behind the placement mutation on the WinForms UI thread, and skips it if the panel was toggled closed meanwhile.
- The existing `test_dpi_scaled_monitor_placement_uses_logical_coordinates` double assumed pywebview already returns logical coordinates with a correct scale — why CI stayed green while hardware broke. It is kept as the "don't double-convert" case.

### 2. Panel doesn't return to its display after relaunch with mixed DPI — c3779b8
`window.x/y` is physical pixels divided by the DPI of the monitor the window is on *at that moment*. A panel closed at physical (2520, 27) on a 225% display was saved as (1120, 12); after relaunch the hidden window starts on the 100% primary and the panel opened there.

- `_save_window_position()` stores physical pixels (the WinForms form's `Left`/`Top`, falling back to logical × window DPI scale).
- `_saved_window_position()` divides by the window's current DPI scale before handing it to the existing placement code.
- Preference key and shape unchanged. At 100% the numbers are identical; values saved earlier on a scaled display are clamped on-screen by the existing logic.

### 3. Bottom of the panel clipped on short scaled screens — 1532887
`fit_scale()` floors zoom at `MIN_PANEL_SCALE` 0.6 for legibility, and `fit_panel_size()` still caps the window at the available height, so when the floor wins the bottom is clipped. On Windows rendered text size is CSS zoom × window DPI scale. At 2560x1440 @225% the work area is 559 logical px; the win95 panel (natural 1064) needs ~0.503 and was held at 0.6, cutting off the rate/status row and the Refresh/Quit buttons. Same arithmetic hits 1920x1080 @175% or 1920x1200 @200% with all four providers shown.

- `fit_scale()` / `fit_panel_size()` take an optional `minimum_scale` (default `MIN_PANEL_SCALE`; macOS callers untouched).
- Windows passes `MIN_PANEL_SCALE / window DPI scale`: 0.6 at 100% (unchanged), 0.267 at 225%. Text still never renders below 0.6× of a 100% display, even for a bogus oversized measurement.

## Test plan
- [x] `ruff check .`, `mypy .`, plus `mypy panels wintray tests/test_panel_scale.py tests/test_wintray.py --platform darwin` for the macOS CI job
- [x] `pytest` — 1507 passed, 5 skipped on Windows 10
- [x] New tests: physical 3840x2040 work area at 2.5x lands inside the logical work area; the report's saved `{"x": 3448, "y": 896}` is clamped on-screen; tall panels zoom to the logical height; show runs after resize/move on the UI thread and is dropped if hidden meanwhile; save uses native physical `Left/Top` or logical × scale; a saved physical position is placed on the right display whether the window starts at DPI scale 1.0 or 2.25; `fit_scale`/`fit_panel_size` with a custom floor; Windows at DPI 2.25 zooms to 535/1064 while DPI 1.0 still floors at 0.6
- [x] `test_physical_dpi_scaled_saved_position_is_clamped_to_logical_screen` expects y=358 after commit 2 (its literal is now read as physical: ÷2.5 → 1379, 358); x still clamps to 1144
- [x] Packaged `usage.exe` on real hardware — primary 1920x1080 @100%, secondary 2560x1440 @225% (DPI 216), tray clicks simulated, screenshots taken:

| Scenario on the 225% display | `main` | this PR |
|---|---|---|
| drag panel there, close / reopen | window 819x1460, bottom at y=1487 — past the 1440 screen edge, ~230px under the taskbar | fully inside the work area |
| far-corner saved position | same overflow | fully inside |
| relaunch app, open | opens on the 100% primary | reopens at (2520, 27) on the 225% display |
| panel content | bottom card off-screen | whole panel visible, including rate/status and Refresh/Quit |

  On the 100% primary the panel is identical to `main` (363x1016, all cards visible).

## Notes for reviewer
- 250% isn't selectable per-monitor on the test displays (225% max; 250% needs global custom scaling and a sign-out). The report's single 3840x2160 @250% primary goes through the same conversion; with a panel like the one tested (natural height 1064) it fits at zoom ~0.74, above the floor.
- The other failure mode in #130 (window exists but `IsWindowVisible` is false) is not explained by these changes. If it persists, a `USAGE_DEBUG=1` log would surface any swallowed error in `_drain_window_mutations`.
- Deliberately not calling `SetProcessDpiAwarenessContext`: the release exe already declares PerMonitorV2 in `scripts/usage.manifest`, and physical `Screen.Bounds` would stay inconsistent either way.
- After a relaunch onto a scaled display the window is placed from the primary, then re-fits once `ResizeObserver` reports the new content height, so the first open can show a brief resize. The end state was inside the work area on every run.
- Short screens at 100% scaling keep the existing 0.6 floor.
- Verified locally that this PR, #132 and #133 squash-merge onto `main` without conflicts.

Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFrJWzQHXFoXPpTYjkKvpe
