### PR TITLE
fix(wintray): 系統匣提示超過 Windows 上限時截斷，不再卡住面板更新

### DIFF
--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import json
 import sys
 import threading
@@ -231,6 +232,30 @@ def test_build_tooltip_includes_antigravity_when_visible() -> None:
         "Antigravity Session: 25% · Weekly: 60%",
     ]
     assert "Antigravity" not in wintray.build_tooltip(_state())
+
+
+def test_build_tooltip_is_safe_for_windows_sz_tip() -> None:
+    base_state = _state()
+    full_row = replace(base_state.claude_session, percent=100.0)
+    state = replace(
+        base_state,
+        hide_agy=False,
+        hide_grok=False,
+        claude_session=full_row,
+        claude_weekly=full_row,
+        codex_session=full_row,
+        codex_weekly=full_row,
+        agy_session=full_row,
+        agy_weekly=full_row,
+        grok_weekly=full_row,
+    )
+
+    tooltip = wintray.build_tooltip(state)
+
+    assert len(tooltip) <= 127
+    assert tooltip.endswith("…")
+    buffer = (ctypes.c_wchar * 128)()
+    buffer.value = tooltip
 
 
 def test_system_background_color_dark(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -77,6 +77,8 @@ logger = logging.getLogger(__name__)
 SLOW_POLL_INTERVAL_S = 300
 HISTORY_SCAN_CACHE_SECONDS = 30.0
 UPDATE_ALERT_BODY_LIMIT = 2000
+# szTip is 128 WCHARs including the terminator; pystray raises ValueError past that.
+TOOLTIP_MAX_LENGTH = 127
 PANEL_WIDTH = 380
 _TOAST_AUMID = "com.lollapalooza.usage"
 _TOAST_OPEN_PANEL_ACTION = "open_panel"
@@ -586,7 +588,8 @@ def build_tooltip(state: menubar_state.PopoverState) -> str:
         )
     if not state.hide_grok:
         lines.append(line("Grok", state.grok_weekly))
-    return "\n".join(lines)
+    text = "\n".join(lines)
+    return text if len(text) <= TOOLTIP_MAX_LENGTH else text[:126] + "…"
 
 
 def draw_tray_icon(used_percent: float | None) -> Image:


### PR DESCRIPTION
## Summary
The Windows tray tooltip can exceed the 128-WCHAR `NOTIFYICONDATAW.szTip` field since the Grok row was added. With the English UI, Antigravity and Grok visible, and every row at 100%, `build_tooltip()` returns 129 characters; pystray then raises `ValueError: string too long (129, maximum length 128)` from `self.icon.title = tooltip`.

That exception is swallowed by `_refresh_worker()`, and it also skips the `inject_state()` call in the same iteration — so an open panel silently stops receiving new data, and the tooltip stays stale on every refresh until the numbers drop. `build_tooltip()` now caps the text at 127 characters (Windows displays at most 127 plus the terminator), ending with `…` when truncated.

Measured worst case with the real i18n strings: en 129, zh-TW/zh-CN 113, ja 107, ko 98 — only English currently overflows, but the cap keeps future label changes safe.

## Test plan
- [x] `ruff check .` (via `.venv` on Windows)
- [x] `mypy .`, plus `mypy wintray tests/test_wintray.py --platform darwin` for the macOS CI job
- [x] `pytest tests/test_wintray.py` — 114 passed, 1 skipped
- [x] New test builds the worst-case state and checks the tooltip fits a `c_wchar * 128` buffer (uses `ctypes.c_wchar`, not `ctypes.wintypes`, so it runs on macOS CI too)

## Notes for reviewer
Found while auditing v0.30.0..main for Windows changes that should have shipped alongside macOS ones; the other candidates (fde1c0c, 2e99c86, 1674ab1, a7927b5, b88c2bc, 1312289, 52230b6, 2c6bb7b, 2551e17) were already equivalent on Windows or macOS-only. Independent of #131.

Both #131 and this PR touch `wintray/app.py` and `tests/test_wintray.py` (different regions). Verified locally that merging #131, #132 and #133 together onto main is conflict-free and `tests/test_wintray.py` passes (119 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFrJWzQHXFoXPpTYjkKvpe