### PR TITLE
fix(hooks): 升狀態列與接續提醒的 hook 版號，讓已安裝的舊副本換新

### DIFF
--- a/installer/session_hooks.py
+++ b/installer/session_hooks.py
@@ -55,7 +55,7 @@ CODEX_CONFIG = setup_hook.CODEX_CONFIG
 # session. Off by default: enabled only via the menu toggle, never by self_heal.
 RESUME_HOOK_TARGET = Path(os.path.expanduser("~/.claude/usage-session-resume.py"))
 RESUME_PROMPT_SIDECAR = Path(os.path.expanduser("~/.claude/usage-resume-prompt.json"))
-RESUME_HOOK_VERSION = "1.6"
+RESUME_HOOK_VERSION = "1.7"
 RESUME_MATCHER = "startup|clear"
 RESUME_LANGS = ("zh-TW", "zh-CN", "en", "ja", "ko")
 _RESUME_MARKER = "usage-session-resume"

--- a/installer/setup_hook.py
+++ b/installer/setup_hook.py
@@ -86,7 +86,7 @@ BACKUP_KEY = "usage"
 LEGACY_TT_BACKUP_KEY = "tokenTracker"
 LEGACY_BACKUP_KEY = LEGACY_NAME
 PREV_SL_KEY = "previousStatusLine"
-HOOK_VERSION = "1.5"
+HOOK_VERSION = "1.6"
 # Antigravity's Go runner hands its status-line command to cmd.exe unquoted, so
 # every character cmd.exe treats specially has to be kept out of the path.
 _CMD_UNSAFE_CHARACTERS = '"&|^<>()'

--- a/tests/test_setup_hook.py
+++ b/tests/test_setup_hook.py
@@ -1201,3 +1201,13 @@ def test_statusline_script_version_matches_hook_constant() -> None:
     match = re.search(r'^__version__ = "([^"]+)"$', source, re.M)
     assert match, "usage_statusline.py has no __version__ line"
     assert match.group(1) == setup_hook.HOOK_VERSION
+
+
+def test_session_resume_script_version_matches_hook_constant() -> None:
+    """Keep the session-resume script version synchronized with its hook constant."""
+    source = (Path(__file__).resolve().parents[1] / "usage_session_resume.py").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r'^__version__ = "([^"]+)"$', source, re.M)
+    assert match, "usage_session_resume.py has no __version__ line"
+    assert match.group(1) == session_hooks.RESUME_HOOK_VERSION

--- a/usage_session_resume.py
+++ b/usage_session_resume.py
@@ -46,7 +46,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast
 
-__version__ = "1.6"
+__version__ = "1.7"
 
 
 def _configure_windows_utf8_output() -> None:

--- a/usage_statusline.py
+++ b/usage_statusline.py
@@ -67,7 +67,7 @@ else:
 fcntl = _fcntl
 msvcrt = _msvcrt
 
-__version__ = "1.5"
+__version__ = "1.6"
 
 STATUS_FILE = os.path.expanduser("~/.claude/usage-status.json")
 LOCK_FILE = os.path.expanduser("~/.claude/usage-status.lock")


### PR DESCRIPTION
## Summary
Installed hook copies are only replaced when the installed file's `__version__` differs from the installer constant (`needs_update()` / the resume self-heal). Two scripts shipped changes without a bump, so every existing install — macOS and Windows — keeps the old copy:

- `usage_statusline.py` got the token-unit boundary fix in 45b27ee (no more `1000k`) but stayed at `1.5`.
- `usage_session_resume.py` has changed in 10 commits since `RESUME_HOOK_VERSION` was set to `1.6` on 2026-07-11 (3041802), including the empty-todo clearing, CJK language boundary, and non-UTF-8 terminal fixes.

Found on a Windows machine running v0.30.12: `~/.claude/usage-statusline.py` (dated 09-01) and `~/.claude/usage-session-resume.py` (dated 07-17) both differ from the repo while reporting the current version; the unversioned agy/Grok status lines and the terse hooks (bumped in 93b2f19) were already current.

- Status line `1.5` -> `1.6`, session resume `1.6` -> `1.7` (script `__version__` and installer constant for each).
- Adds `test_session_resume_script_version_matches_hook_constant`, mirroring the existing status-line test, so a one-sided bump can't make self-heal reinstall on every launch.

## Test plan
- [x] `ruff check` / `mypy` (plus `--platform darwin`) on the touched files
- [x] `pytest` — 1494 passed, 5 skipped on Windows
- [x] After building and launching, the installed copies on this machine are replaced (verified locally)

## Notes for reviewer
This is the third time a hook script changed without a version bump (see 1002370, 95ff0e8). A guard that fails CI when a hook script's content changes but its version does not would stop the recurrence; left out of this PR since it changes the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFrJWzQHXFoXPpTYjkKvpe