### PR TITLE
fix(wintray): 面板位置改存實體像素，混合縮放多螢幕重開後回到原螢幕

### DIFF
--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -382,6 +382,102 @@ def test_panel_position_is_clamped_and_persisted_on_hide(
     assert prefs._load_preferences()["usage.windowPosition"] == {"x": 123, "y": 234}
 
 
+def test_panel_position_is_saved_as_native_physical_pixels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        native=SimpleNamespace(Left=2520, Top=27), x=1120, y=12, hide=lambda: None
+    )
+    controller.visible = True
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller.show_panel()
+
+    assert prefs._load_preferences()["usage.windowPosition"] == {"x": 2520, "y": 27}
+
+
+def test_panel_position_falls_back_to_scaled_logical_pixels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(x=1120, y=12, hide=lambda: None)
+    controller.visible = True
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller.show_panel()
+
+    assert prefs._load_preferences()["usage.windowPosition"] == {"x": 2520, "y": 27}
+
+
+def test_physical_saved_position_returns_to_secondary_screen_after_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    preferences_path.write_text(
+        json.dumps({"usage.windowPosition": {"x": 2520, "y": 27}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    screens = [
+        SimpleNamespace(
+            x=0, y=0, width=1920, height=1080,
+            frame=SimpleNamespace(Left=0, Top=0, Right=1920, Bottom=1040), scale=1.0,
+        ),
+        SimpleNamespace(
+            x=1920, y=0, width=2560, height=1440,
+            frame=SimpleNamespace(Left=1920, Top=0, Right=4480, Bottom=1258), scale=1.0,
+        ),
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    moves: list[tuple[int, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0, y=0, resize=lambda *_args: None, move=lambda x, y: moves.append((x, y))
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 1.0)
+
+    controller._place_window()
+
+    assert moves == [(2520, 27)]
+
+
+def test_physical_saved_position_uses_current_secondary_dpi_scale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    preferences_path = tmp_path / "usage-preferences.json"
+    preferences_path.write_text(
+        json.dumps({"usage.windowPosition": {"x": 2520, "y": 27}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(prefs, "PREFERENCES_FILE", preferences_path)
+    screens = [
+        SimpleNamespace(
+            x=0, y=0, width=1920, height=1080,
+            frame=SimpleNamespace(Left=0, Top=0, Right=1920, Bottom=1040), scale=1.0,
+        ),
+        SimpleNamespace(
+            x=1920, y=0, width=2560, height=1440,
+            frame=SimpleNamespace(Left=1920, Top=0, Right=4480, Bottom=1258), scale=1.0,
+        ),
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    moves: list[tuple[int, int]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0, y=0, resize=lambda *_args: None, move=lambda x, y: moves.append((x, y))
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller._place_window()
+
+    assert moves == [(1120, 12)]
+
+
 def test_dpi_scaled_monitor_placement_uses_logical_coordinates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -480,7 +576,7 @@ def test_physical_dpi_scaled_saved_position_is_clamped_to_logical_screen(
 
     controller._place_window()
 
-    assert moves == [(1144, 404)]
+    assert moves == [(1144, 358)]
 
 
 def test_physical_dpi_scaled_screens_use_logical_height_for_panel_zoom(

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -1021,7 +1021,8 @@ class _WindowsTrayController:
             return None
         if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
             return None
-        return (int(x), int(y))
+        scale = self._window_dpi_scale() or 1.0
+        return (int(round(x / scale)), int(round(y / scale)))
 
     def _current_window_position(self) -> tuple[int, int] | None:
         if self.window is None:
@@ -1035,6 +1036,24 @@ class _WindowsTrayController:
         if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
             return None
         return (int(x), int(y))
+
+    def _physical_window_position(self) -> tuple[int, int] | None:
+        if self.window is None:
+            return None
+        try:
+            native = self.window.native
+            x, y = native.Left, native.Top
+        except Exception:
+            x = y = None
+        if not isinstance(x, bool) and not isinstance(y, bool) and isinstance(
+            x, int | float
+        ) and isinstance(y, int | float):
+            return (int(round(x)), int(round(y)))
+        position = self._current_window_position()
+        if position is None:
+            return None
+        scale = self._window_dpi_scale() or 1.0
+        return (int(round(position[0] * scale)), int(round(position[1] * scale)))
 
     @staticmethod
     def _clamp_window_position(
@@ -1164,7 +1183,8 @@ class _WindowsTrayController:
                     logger.warning("Window mutation failed", exc_info=True)
 
     def _save_window_position(self) -> None:
-        position = self._current_window_position()
+        # Logical coordinates are tied to the window's current monitor DPI.
+        position = self._physical_window_position()
         if position is None:
             return
         preferences = _load_preferences()


### PR DESCRIPTION
## Summary
Stacked on #131 (uses its `_window_dpi_scale()`); base will need retargeting to `main` once #131 merges.

With mixed-DPI monitors the tray panel doesn't come back to the display it was left on. `_save_window_position()` stored pywebview's `window.x/y`, which is physical pixels divided by the DPI of the monitor the window is on *at that moment*. A panel closed at physical (2520, 27) on a 225% display was saved as (1120, 12); after relaunching, the hidden window starts on the 100% primary, the same numbers are read back as primary-monitor coordinates, and the panel opens on the primary at x=1120.

- `_save_window_position()` now stores physical pixels: the WinForms form's `Left`/`Top` (physical in the PerMonitorV2 release exe), falling back to logical × the window's DPI scale when there is no native form.
- `_saved_window_position()` divides by the window's current DPI scale, handing the existing placement/clamping code logical coordinates in the space `move()` expects.
- The preference key and shape (`usage.windowPosition` → `{"x", "y"}`) are unchanged. At 100% the stored numbers are identical; values saved earlier on a scaled display are read as smaller physical coordinates and clamped on-screen by the existing logic, so no migration.

## Test plan
- [x] `ruff check .`, `mypy .`, `mypy wintray tests/test_wintray.py --platform darwin`
- [x] `pytest` — 1502 passed, 5 skipped on Windows
- [x] 4 new tests: save uses native physical `Left/Top`; save falls back to logical × scale; a saved physical position on the secondary display is placed there when the window starts on the 100% primary; the same position is placed correctly when the window is already on the 225% display
- [x] `test_physical_dpi_scaled_saved_position_is_clamped_to_logical_screen` (from #131) now expects y=358 instead of 404: its literal `{"x": 3448, "y": 896}` is read as physical (÷2.5 → 1379, 358) rather than logical; x still clamps to 1144 and the point of the test — a bad saved value lands on-screen — is unchanged
- [x] Real hardware, packaged `usage.exe`, primary 1920x1080 @100% + secondary 2560x1440 @225% (DPI 216), tray clicks simulated:

| Step | before (#131 only) | this PR |
|---|---|---|
| drag panel to 225% display, close | saved `{x: 1120, y: 12}` | saved `{x: 2520, y: 27}` |
| close / reopen ×2 | stays on 225% display | stays on 225% display |
| **relaunch app, open** | **opens on primary at (1120, 12)** | **opens on 225% display at (2520, 27)** |
| far-corner saved position | inside work area | inside work area |

## Notes for reviewer
After relaunch the window is created on the primary, placed onto the scaled display, and then re-fits once `ResizeObserver` reports the new content height after the DPI change — so the first open after a relaunch can show a brief resize. The end state was inside the work area on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFrJWzQHXFoXPpTYjkKvpe