### PR TITLE
fix(wintray): 高 DPI 螢幕的面板縮放下限改以實際像素計，底部不再被裁掉

### DIFF
--- a/panels/panel_scale.py
+++ b/panels/panel_scale.py
@@ -9,8 +9,10 @@ from typing import cast
 MIN_PANEL_SCALE = 0.6
 
 
-def fit_scale(natural_height: object, maximum: object) -> float:
-    """Ratio that fits natural_height into maximum, never below MIN_PANEL_SCALE."""
+def fit_scale(
+    natural_height: object, maximum: object, minimum_scale: float = MIN_PANEL_SCALE
+) -> float:
+    """Ratio that fits natural_height into maximum, never below minimum_scale."""
     if (
         isinstance(natural_height, bool)
         or isinstance(maximum, bool)
@@ -24,14 +26,17 @@ def fit_scale(natural_height: object, maximum: object) -> float:
         return 1.0
     if natural <= available:
         return 1.0
-    return max(MIN_PANEL_SCALE, available / natural)
+    return max(minimum_scale, available / natural)
 
 
 def fit_panel_size(
-    natural_width: object, natural_height: object, maximum: object
+    natural_width: object,
+    natural_height: object,
+    maximum: object,
+    minimum_scale: float = MIN_PANEL_SCALE,
 ) -> tuple[float, float, float]:
-    """Return (width, height, scale) fitted into maximum, height never exceeding it."""
-    scale = fit_scale(natural_height, maximum)
+    """Return (width, height, scale) fitted into maximum with a specified minimum scale."""
+    scale = fit_scale(natural_height, maximum, minimum_scale)
     if (
         isinstance(natural_width, bool)
         or not isinstance(natural_width, int | float)

--- a/tests/test_panel_scale.py
+++ b/tests/test_panel_scale.py
@@ -29,6 +29,16 @@ def test_fit_scale(natural_height: object, maximum: object, expected: float) -> 
     assert fit_scale(natural_height, maximum) == expected
 
 
+def test_fit_scale_uses_supplied_minimum_for_high_dpi_panel() -> None:
+    minimum_scale = 0.6 / 2.25
+    assert fit_scale(1064.0, 535.0, minimum_scale=minimum_scale) == 535.0 / 1064.0
+
+
+def test_fit_scale_respects_supplied_minimum() -> None:
+    minimum_scale = 0.6 / 2.25
+    assert fit_scale(4000.0, 535.0, minimum_scale=minimum_scale) == minimum_scale
+
+
 @pytest.mark.parametrize(
     (
         "natural_width",
@@ -70,3 +80,11 @@ def test_fit_panel_size(
         assert width == expected_width
     assert height == expected_height
     assert scale == expected_scale
+
+
+def test_fit_panel_size_uses_supplied_minimum_for_high_dpi_panel() -> None:
+    minimum_scale = 0.6 / 2.25
+    width, height, scale = fit_panel_size(380.0, 1064.0, 535.0, minimum_scale)
+    assert height == 535.0
+    assert scale == 535.0 / 1064.0
+    assert width == 380.0 * scale

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -617,6 +617,80 @@ def test_physical_dpi_scaled_screens_use_logical_height_for_panel_zoom(
     assert mutations[0] == ("resize", 301, 792)
 
 
+def test_high_dpi_panel_zoom_can_fit_below_css_legibility_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=2560,
+            height=1440,
+            frame=SimpleNamespace(Left=0, Top=0, Right=2560, Bottom=1258),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    javascript: list[str] = []
+    mutations: list[tuple[str, int, int]] = []
+
+    def evaluate_js(code: str) -> bool:
+        javascript.append(code)
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        evaluate_js=evaluate_js,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda *_args: None,
+    )
+    controller._content_height = 1064
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 2.25)
+
+    controller._place_window()
+
+    assert "usageApplyPanelZoom(0.5028195488721805, 1064)" in javascript[-1]
+    assert mutations[0] == ("resize", 191, 535)
+
+
+def test_standard_dpi_panel_zoom_keeps_css_legibility_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screens = [
+        SimpleNamespace(
+            x=0,
+            y=0,
+            width=1920,
+            height=1080,
+            frame=SimpleNamespace(Left=0, Top=0, Right=1920, Bottom=560),
+            scale=1.0,
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace(screens=screens))
+    javascript: list[str] = []
+
+    def evaluate_js(code: str) -> bool:
+        javascript.append(code)
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        evaluate_js=evaluate_js,
+        resize=lambda *_args: None,
+        move=lambda *_args: None,
+    )
+    controller._content_height = 1064
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 1.0)
+
+    controller._place_window()
+
+    assert "usageApplyPanelZoom(0.6, 1064)" in javascript[-1]
+
+
 def test_content_height_keeps_the_panels_natural_height(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -49,7 +49,7 @@ from menubar.prefs import (
     _window_keeper_enabled,
 )
 from panels.dynamic_height import clamp_content_height, inject_content_height_script
-from panels.panel_scale import fit_panel_size, fit_scale
+from panels.panel_scale import MIN_PANEL_SCALE, fit_panel_size, fit_scale
 from panels.payload import _load_panel_html, _state_payload
 from prefs import _load_preferences, _save_preferences
 from pricing import calculate_cost
@@ -1072,6 +1072,10 @@ class _WindowsTrayController:
         left, top, right, bottom = work_area
         return (max(left + 12, right - width - 12), max(top + 12, bottom - height - 12))
 
+    # The legibility floor uses physical pixels: CSS zoom times window DPI scale.
+    def _panel_minimum_scale(self) -> float:
+        return MIN_PANEL_SCALE / (self._window_dpi_scale() or 1.0)
+
     def _place_window(self, *, force_default: bool = False) -> None:
         current_position = self._current_window_position()
         work_area = self._work_area_for_point(current_position) or self._working_area()
@@ -1080,7 +1084,7 @@ class _WindowsTrayController:
             if work_area is not None
             else float(PANEL_HEIGHTS[self.active_panel_id])
         )
-        scale = fit_scale(self.panel_height(), maximum)
+        scale = fit_scale(self.panel_height(), maximum, self._panel_minimum_scale())
         zoom_applied = self._apply_panel_zoom(scale)
         if scale < 1.0 and not zoom_applied:
             return
@@ -1115,7 +1119,9 @@ class _WindowsTrayController:
         left, top, right, bottom = work_area
         maximum = float(bottom - top - 24)
         natural_height = self.panel_height()
-        fitted_width, fitted_height, scale = fit_panel_size(PANEL_WIDTH, natural_height, maximum)
+        fitted_width, fitted_height, scale = fit_panel_size(
+            PANEL_WIDTH, natural_height, maximum, self._panel_minimum_scale()
+        )
         width = int(round(fitted_width))
         height = int(round(fitted_height))
         self.window.resize(width, height)


### PR DESCRIPTION
## Summary
Stacked on #134 (→ #131); retarget the base to `main` after those merge.

`fit_scale()` floors the panel zoom at `MIN_PANEL_SCALE` 0.6 so text never gets too small. On Windows the size text actually renders at is CSS zoom × the window's DPI scale, so a fixed 0.6 is far stricter than it needs to be on scaled displays — and when the floor wins, `fit_panel_size()` still caps the window at the available height, so the bottom of the panel is clipped. That is exactly the case a12f604 set out to remove.

Real hardware: 2560x1440 at 225% leaves a 559-logical-pixel work area (`maximum` 535). The win95 panel's natural height is 1064, which needs a zoom of ~0.503; it was held at 0.6, and the bottom card — rate, sync status, today's total, **Refresh and Quit** — was cut off entirely. The same arithmetic clips it on common laptop setups such as 1920x1080 at 175% or 1920x1200 at 200% once all four providers are shown.

- `fit_scale()` / `fit_panel_size()` take an optional `minimum_scale`, defaulting to `MIN_PANEL_SCALE`; macOS callers are untouched.
- Windows passes `MIN_PANEL_SCALE / window DPI scale`: 0.6 at 100% (unchanged), 0.267 at 225%. The physical floor still holds, so a bogus oversized measurement can't shrink text below 0.6× of a 100% display.

## Test plan
- [x] `ruff check .`, `mypy .`, `mypy panels wintray tests/... --platform darwin`
- [x] `pytest` — 1507 passed, 5 skipped on Windows (existing tests unchanged)
- [x] New tests: `fit_scale` / `fit_panel_size` with a custom floor; Windows placement at DPI scale 2.25 zooms to 535/1064 instead of 0.6; at DPI scale 1.0 the same short screen still floors at 0.6
- [x] Real hardware, packaged `usage.exe`, panel on the 2560x1440 @225% display, screenshots after the panel settled:
  - before (#134): window 513x1203, zoom held at 0.6, content cut off below the Project Usage card — the bottom card is missing
  - this PR: window 405x1203, whole panel visible including the rate/status row and the Refresh/Quit buttons
  - both builds show an identical panel on the 100% primary

## Notes for reviewer
Short screens at 100% scaling keep the existing 0.6 floor and can still clip in extreme cases; that trade-off is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFrJWzQHXFoXPpTYjkKvpe