### PR TITLE
fix(windows): 修掉啟動時的黑窗連閃與面板先閃在舊位置

### DIFF
--- a/installer/login_item.py
+++ b/installer/login_item.py
@@ -16,6 +16,8 @@ from typing import Any
 
 from Foundation import NSBundle
 
+from usage_common.subprocess_utils import hidden_console_kwargs
+
 logger = logging.getLogger(__name__)
 
 LABEL = "com.lollapalooza.usage"
@@ -106,6 +108,8 @@ def _launchctl_bootstrap() -> None:
             errors="replace",
             check=False,
             timeout=5,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
     except FileNotFoundError as exc:
         _log_launchctl_error("bootstrap", str(exc))
@@ -140,6 +144,8 @@ def _launchctl_bootout() -> None:
             errors="replace",
             check=False,
             timeout=5,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
     except FileNotFoundError as exc:
         _log_launchctl_error(

--- a/installer/session_hooks.py
+++ b/installer/session_hooks.py
@@ -24,6 +24,7 @@ from i18n import t as _t
 from installer import setup_hook
 from installer.setup_hook import (
     BACKUP_KEY,
+    FORWARDER_VERSION,
     HOOK_VERSION,
     _atomic_write_text,
     _copy_forwarder_script,
@@ -32,6 +33,7 @@ from installer.setup_hook import (
     _ensure_table_line,
     _find_system_python,
     _forwarder_command,
+    _installed_forwarder_version,
     _installed_hook_version,
     _load_settings,
     _read_codex_config,
@@ -40,9 +42,11 @@ from installer.setup_hook import (
     _statusline_command,
     _statusline_command_target_exists,
     _uses_bundled_app_python,
+    forwarder_needs_update,
     is_setup,
     needs_update,
     setup,
+    update_forwarder,
     update_hook,
 )
 from loaders.codex_paths import codex_home
@@ -55,7 +59,7 @@ CODEX_CONFIG = setup_hook.CODEX_CONFIG
 # session. Off by default: enabled only via the menu toggle, never by self_heal.
 RESUME_HOOK_TARGET = Path(os.path.expanduser("~/.claude/usage-session-resume.py"))
 RESUME_PROMPT_SIDECAR = Path(os.path.expanduser("~/.claude/usage-resume-prompt.json"))
-RESUME_HOOK_VERSION = "1.7"
+RESUME_HOOK_VERSION = "1.8"
 RESUME_MATCHER = "startup|clear"
 RESUME_LANGS = ("zh-TW", "zh-CN", "en", "ja", "ko")
 _RESUME_MARKER = "usage-session-resume"
@@ -1142,6 +1146,20 @@ def self_heal() -> None:
         if isinstance(exc, KeyboardInterrupt):
             raise
         _debug_self_heal_failure("update_hook", exc)
+
+    try:
+        state = _detect_current_state()
+        if state in {"external", "legacy-tt"}:
+            return
+        old_version = _installed_forwarder_version()
+        if forwarder_needs_update():
+            _run_quietly(update_forwarder)
+            detail = f"{old_version or 'unknown'} -> {FORWARDER_VERSION}"
+            _append_self_heal_log("update_forwarder", detail)
+    except BaseException as exc:
+        if isinstance(exc, KeyboardInterrupt):
+            raise
+        _debug_self_heal_failure("update_forwarder", exc)
 
     try:
         state = _detect_current_state()

--- a/installer/setup_hook.py
+++ b/installer/setup_hook.py
@@ -37,6 +37,7 @@ from typing import Any, cast
 from i18n import t as _t
 from loaders.claude_paths import claude_home
 from loaders.codex_paths import codex_home
+from usage_common.subprocess_utils import hidden_console_kwargs
 
 HOOK_TARGET = Path(os.path.expanduser("~/.claude/usage-statusline.py"))
 FORWARDER_TARGET = Path(os.path.expanduser("~/.claude/usage-statusline-forwarder.py"))
@@ -87,6 +88,7 @@ LEGACY_TT_BACKUP_KEY = "tokenTracker"
 LEGACY_BACKUP_KEY = LEGACY_NAME
 PREV_SL_KEY = "previousStatusLine"
 HOOK_VERSION = "1.6"
+FORWARDER_VERSION = "1.1"
 # Antigravity's Go runner hands its status-line command to cmd.exe unquoted, so
 # every character cmd.exe treats specially has to be kept out of the path.
 _CMD_UNSAFE_CHARACTERS = '"&|^<>()'
@@ -212,7 +214,13 @@ def _statusline_command_target_exists() -> bool:
 def _is_working_python(path: str) -> bool:
     """Return whether ``path`` can run as a Python interpreter."""
     try:
-        result = subprocess.run([path, "--version"], capture_output=True, timeout=3)
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            timeout=3,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
+        )
     except (OSError, subprocess.TimeoutExpired):
         return False
     return result.returncode == 0
@@ -1164,16 +1172,40 @@ def _installed_hook_version() -> str | None:
     return None
 
 
+def _installed_forwarder_version() -> str | None:
+    try:
+        with FORWARDER_TARGET.open(encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("__version__"):
+                    _, sep, value = line.partition("=")
+                    if not sep:
+                        return None
+                    return value.strip().strip("\"'")
+    except (OSError, UnicodeDecodeError):
+        pass
+    return None
+
+
 def needs_update() -> bool:
     if not HOOK_TARGET.parent.exists():
         return False
     return _installed_hook_version() != HOOK_VERSION
 
 
+def forwarder_needs_update() -> bool:
+    if not FORWARDER_TARGET.exists():
+        return False
+    return _installed_forwarder_version() != FORWARDER_VERSION
+
+
 def update_hook() -> None:
     if not HOOK_TARGET.parent.exists():
         return
     _copy_hook_script()
+
+
+def update_forwarder() -> None:
+    _copy_forwarder_script()
 
 
 

--- a/loaders/agy_quota_probe.py
+++ b/loaders/agy_quota_probe.py
@@ -34,6 +34,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from usage_common.subprocess_utils import hidden_console_kwargs
+
 CACHE_PATH = Path(os.path.expanduser("~/.usage/agy_quota_cache.json"))
 # Legacy OAuth token written by older Antigravity CLI versions. Read-only: we
 # never write back here (that is the CLI's home and could corrupt its login).
@@ -222,6 +224,8 @@ def _read_macos_credential() -> object:
             check=False,
             capture_output=True,
             timeout=5,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
     except (OSError, subprocess.SubprocessError):
         return None

--- a/loaders/claude_paths.py
+++ b/loaders/claude_paths.py
@@ -14,6 +14,8 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 
+from usage_common.subprocess_utils import hidden_console_kwargs
+
 
 def _configured_value() -> str:
     value = os.environ.get("CLAUDE_CONFIG_DIR", "")
@@ -29,6 +31,7 @@ def _configured_value() -> str:
             encoding="utf-8",
             timeout=2,
             stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
     except Exception:
         return ""

--- a/project_resolver.py
+++ b/project_resolver.py
@@ -11,6 +11,8 @@ import subprocess
 from functools import lru_cache
 from pathlib import Path
 
+from usage_common.subprocess_utils import hidden_console_kwargs
+
 __all__ = ["project_from_encoded_path", "resolve_project_name"]
 
 
@@ -38,6 +40,8 @@ def _resolve_project_name(normalized_cwd: str) -> str:
             encoding="utf-8",
             errors="replace",
             timeout=3,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return fallback

--- a/quota/agy_window_keeper.py
+++ b/quota/agy_window_keeper.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from menubar.agy import AgyRefreshResult
 from menubar.prefs import _agy_window_keeper_enabled
+from usage_common.subprocess_utils import hidden_console_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,7 @@ def _run_agy_ping(agy_bin: str) -> None:
         timeout=PING_TIMEOUT_SECONDS,
         cwd=os.path.expanduser("~"),
         check=False,
+        **hidden_console_kwargs(),
     )
 
 

--- a/quota/codex_window_keeper.py
+++ b/quota/codex_window_keeper.py
@@ -42,6 +42,7 @@ from pathlib import Path
 
 from loaders.codex_loader import load_rate_limits
 from menubar.prefs import _window_keeper_enabled
+from usage_common.subprocess_utils import hidden_console_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +206,7 @@ def _run_codex_ping(codex_bin: str) -> None:
         timeout=PING_TIMEOUT_SECONDS,
         cwd=os.path.expanduser("~"),
         check=False,
+        **hidden_console_kwargs(),
     )
 
 

--- a/quota/window_keeper.py
+++ b/quota/window_keeper.py
@@ -44,6 +44,7 @@ from contextlib import suppress
 from pathlib import Path
 
 from menubar.prefs import _window_keeper_enabled
+from usage_common.subprocess_utils import hidden_console_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +198,7 @@ def _run_claude_ping(claude_bin: str) -> None:
         timeout=PING_TIMEOUT_SECONDS,
         cwd=os.path.expanduser("~"),
         check=False,
+        **hidden_console_kwargs(),
     )
 
 

--- a/tests/test_hook_scripts_are_standalone.py
+++ b/tests/test_hook_scripts_are_standalone.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 lollapalooza <https://github.com/aqua5230>
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_IMPORT_ROOTS = {
+    "analyzer",
+    "i18n",
+    "installer",
+    "loaders",
+    "menubar",
+    "panels",
+    "quota",
+    "ui",
+    "usage_common",
+}
+HOOK_SCRIPTS = (
+    "usage_session_resume.py",
+    "usage_statusline_forwarder.py",
+    "usage_statusline.py",
+    "usage_terse_mode.py",
+    "usage_terse_reminder.py",
+)
+
+
+@pytest.mark.parametrize("script_name", HOOK_SCRIPTS)
+def test_copied_hook_scripts_have_no_project_imports(script_name: str) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    tree = ast.parse((project_root / script_name).read_text(encoding="utf-8"))
+    imported_roots: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imported_roots.update(alias.name.partition(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_roots.add(node.module.partition(".")[0])
+
+    assert imported_roots.isdisjoint(PROJECT_IMPORT_ROOTS)

--- a/tests/test_login_item.py
+++ b/tests/test_login_item.py
@@ -126,7 +126,7 @@ def test_enable_bootstrap_returncode_0_keeps_plist_and_uses_safe_subprocess(
     tmp_path: Path,
 ) -> None:
     plist_path = _configure_login_item_paths(monkeypatch, tmp_path)
-    calls: list[tuple[list[str], bool, bool, str, str, bool, int]] = []
+    calls: list[tuple[list[str], bool, bool, str, str, bool, int, int]] = []
 
     def fake_getuid() -> int:
         return 501
@@ -140,8 +140,9 @@ def test_enable_bootstrap_returncode_0_keeps_plist_and_uses_safe_subprocess(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        calls.append((cmd, capture_output, text, encoding, errors, check, timeout))
+        calls.append((cmd, capture_output, text, encoding, errors, check, timeout, stdin))
         return _completed(cmd, 0)
 
     monkeypatch.setattr("installer.login_item.os.getuid", fake_getuid)
@@ -159,6 +160,7 @@ def test_enable_bootstrap_returncode_0_keeps_plist_and_uses_safe_subprocess(
             "replace",
             False,
             5,
+            subprocess.DEVNULL,
         )
     ]
     assert isinstance(calls[0][0], list)
@@ -179,8 +181,9 @@ def test_enable_bootstrap_returncode_17_keeps_plist_without_error(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        _ = capture_output, text, check, timeout
+        _ = capture_output, text, check, timeout, stdin
         return _completed(cmd, 17, "Bootstrap failed: 17: File exists")
 
     monkeypatch.setattr("installer.login_item.subprocess.run", fake_run)
@@ -206,8 +209,9 @@ def test_enable_bootstrap_unexpected_returncode_warns_and_keeps_plist(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        _ = capture_output, text, check, timeout
+        _ = capture_output, text, check, timeout, stdin
         return _completed(cmd, 5, "permission denied")
 
     monkeypatch.setattr("installer.login_item.subprocess.run", fake_run)
@@ -245,8 +249,9 @@ def test_enable_bootstrap_subprocess_exception_warns_and_keeps_plist(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        _ = cmd, capture_output, text, check, timeout
+        _ = cmd, capture_output, text, check, timeout, stdin
         raise side_effect
 
     monkeypatch.setattr("installer.login_item.subprocess.run", fake_run)
@@ -266,7 +271,7 @@ def test_disable_bootout_returncode_0_removes_plist_and_uses_safe_subprocess(
     plist_path = _configure_login_item_paths(monkeypatch, tmp_path)
     plist_path.parent.mkdir(parents=True)
     plist_path.write_text("plist", encoding="utf-8")
-    calls: list[tuple[list[str], bool, bool, str, str, bool, int]] = []
+    calls: list[tuple[list[str], bool, bool, str, str, bool, int, int]] = []
 
     def fake_getuid() -> int:
         return 501
@@ -280,8 +285,9 @@ def test_disable_bootout_returncode_0_removes_plist_and_uses_safe_subprocess(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        calls.append((cmd, capture_output, text, encoding, errors, check, timeout))
+        calls.append((cmd, capture_output, text, encoding, errors, check, timeout, stdin))
         return _completed(cmd, 0)
 
     monkeypatch.setattr("installer.login_item.os.getuid", fake_getuid)
@@ -299,6 +305,7 @@ def test_disable_bootout_returncode_0_removes_plist_and_uses_safe_subprocess(
             "replace",
             False,
             5,
+            subprocess.DEVNULL,
         )
     ]
     assert isinstance(calls[0][0], list)
@@ -321,8 +328,9 @@ def test_disable_bootout_returncode_113_removes_plist_without_error(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        _ = capture_output, text, check, timeout
+        _ = capture_output, text, check, timeout, stdin
         return _completed(cmd, 113, "could not find specified service")
 
     monkeypatch.setattr("installer.login_item.subprocess.run", fake_run)
@@ -350,8 +358,9 @@ def test_disable_bootout_unexpected_returncode_warns_and_removes_plist(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        _ = capture_output, text, check, timeout
+        _ = capture_output, text, check, timeout, stdin
         return _completed(cmd, 5, "bad service")
 
     monkeypatch.setattr("installer.login_item.subprocess.run", fake_run)
@@ -383,8 +392,9 @@ def test_disable_bootout_file_not_found_warns_and_removes_plist(
         errors: str,
         check: bool,
         timeout: int,
+        stdin: int,
     ) -> subprocess.CompletedProcess[str]:
-        _ = cmd, capture_output, text, check, timeout
+        _ = cmd, capture_output, text, check, timeout, stdin
         raise FileNotFoundError("launchctl missing")
 
     monkeypatch.setattr("installer.login_item.subprocess.run", fake_run)

--- a/tests/test_setup_hook.py
+++ b/tests/test_setup_hook.py
@@ -1097,6 +1097,93 @@ def test_self_heal_updates_owned_hook(
     assert data["usage"]["selfHealLog"][-1]["action"] == "update_hook"
 
 
+def test_self_heal_updates_old_forwarder(setup_paths: SetupHookPaths) -> None:
+    settings = setup_paths.settings
+    forwarder_target = setup_paths.forwarder_target
+    setup_paths.forwarder_source.write_text('__version__ = "1.1"\n', encoding="utf-8")
+    settings.write_text(
+        json.dumps(
+            {
+                "statusLine": {
+                    "type": "command",
+                    "command": expected_statusline_command(forwarder_target),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    forwarder_target.write_text('__version__ = "1.0"\n', encoding="utf-8")
+
+    session_hooks.self_heal()
+
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert forwarder_target.read_text(encoding="utf-8") == '__version__ = "1.1"\n'
+    assert data["usage"]["selfHealLog"][-1]["action"] == "update_forwarder"
+    assert data["usage"]["selfHealLog"][-1]["detail"] == "1.0 -> 1.1"
+
+
+def test_self_heal_keeps_current_forwarder_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    setup_paths: SetupHookPaths,
+) -> None:
+    settings = setup_paths.settings
+    forwarder_target = setup_paths.forwarder_target
+    setup_paths.hook_target.write_text(
+        f'__version__ = "{setup_hook.HOOK_VERSION}"\n', encoding="utf-8"
+    )
+    forwarder_target.write_text(
+        f'__version__ = "{setup_hook.FORWARDER_VERSION}"\n', encoding="utf-8"
+    )
+    settings.write_text(
+        json.dumps(
+            {
+                "statusLine": {
+                    "type": "command",
+                    "command": expected_statusline_command(forwarder_target),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    updates: list[None] = []
+    monkeypatch.setattr(session_hooks, "update_forwarder", lambda: updates.append(None))
+
+    session_hooks.self_heal()
+
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert updates == []
+    assert forwarder_target.read_text(encoding="utf-8") == (
+        f'__version__ = "{setup_hook.FORWARDER_VERSION}"\n'
+    )
+    assert "usage" not in data
+
+
+def test_missing_forwarder_does_not_install_for_direct_statusline(
+    setup_paths: SetupHookPaths,
+) -> None:
+    settings = setup_paths.settings
+    hook_target = setup_paths.hook_target
+    hook_target.write_text(f'__version__ = "{setup_hook.HOOK_VERSION}"\n', encoding="utf-8")
+    settings.write_text(
+        json.dumps(
+            {
+                "statusLine": {
+                    "type": "command",
+                    "command": expected_statusline_command(hook_target),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not setup_hook.forwarder_needs_update()
+
+    session_hooks.self_heal()
+
+    assert not setup_paths.forwarder_target.exists()
+    assert "usage" not in json.loads(settings.read_text(encoding="utf-8"))
+
+
 def test_self_heal_migrates_bundled_python_commands(
     monkeypatch: pytest.MonkeyPatch,
     setup_paths: SetupHookPaths,
@@ -1211,3 +1298,13 @@ def test_session_resume_script_version_matches_hook_constant() -> None:
     match = re.search(r'^__version__ = "([^"]+)"$', source, re.M)
     assert match, "usage_session_resume.py has no __version__ line"
     assert match.group(1) == session_hooks.RESUME_HOOK_VERSION
+
+
+def test_statusline_forwarder_version_matches_hook_constant() -> None:
+    """Keep the status-line forwarder version synchronized with its hook constant."""
+    source = (
+        Path(__file__).resolve().parents[1] / "usage_statusline_forwarder.py"
+    ).read_text(encoding="utf-8")
+    match = re.search(r'^__version__ = "([^"]+)"$', source, re.M)
+    assert match, "usage_statusline_forwarder.py has no __version__ line"
+    assert match.group(1) == setup_hook.FORWARDER_VERSION

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 lollapalooza <https://github.com/aqua5230>
+#
+# Part of "usage". Free software licensed under the GNU Affero General Public
+# License v3.0 only; see the LICENSE file for full terms and the warranty disclaimer.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from usage_common.subprocess_utils import hidden_console_kwargs
+
+
+def test_hidden_console_kwargs_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    assert hidden_console_kwargs() == {
+        "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    }
+
+
+def test_hidden_console_kwargs_on_other_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    assert hidden_console_kwargs() == {}

--- a/tests/test_usage_statusline_forwarder.py
+++ b/tests/test_usage_statusline_forwarder.py
@@ -60,6 +60,7 @@ def test_main_fans_stdin_out_to_all_hooks(
         check: bool,
         capture_output: bool,
         timeout: int,
+        **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
         assert text is True
         assert encoding == "utf-8"
@@ -123,6 +124,7 @@ def test_timeout_hook_does_not_block_later_hooks(
         check: bool,
         capture_output: bool,
         timeout: int,
+        **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
         _ = input, text, encoding, errors, check, capture_output
         calls.append(cmd[1])
@@ -156,6 +158,7 @@ def test_nonzero_hook_exit_keeps_forwarder_successful(
         check: bool,
         capture_output: bool,
         timeout: int,
+        **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
         _ = input, text, encoding, errors, check, capture_output, timeout
         if cmd[1] == "/tmp/fail-statusline.py":
@@ -187,6 +190,7 @@ def test_unicode_decode_error_hook_does_not_block_later_hooks(
         check: bool,
         capture_output: bool,
         timeout: int,
+        **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
         _ = input, text, encoding, errors, check, capture_output, timeout
         if cmd[1] == "/tmp/bad-statusline.py":

--- a/tests/test_wintray.py
+++ b/tests/test_wintray.py
@@ -542,6 +542,199 @@ def test_dpi_scaled_monitor_placement_uses_logical_coordinates(
     assert mutations == [("resize", 380, 400), ("move", 2424, 268)]
 
 
+def test_hidden_panel_placement_uses_geometry_without_showing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mutations: list[tuple[object, ...]] = []
+
+    def apply_geometry(width: int, height: int, x: int, y: int) -> bool:
+        mutations.append(("SetWindowPos", width, height, x, y))
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller.visible = True
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(
+        controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800)
+    )
+    monkeypatch.setattr(
+        controller,
+        "_apply_geometry_without_showing",
+        apply_geometry,
+    )
+
+    controller._place_window_on_ui_thread()
+
+    assert mutations == [("SetWindowPos", 380, 400, 608, 388)]
+
+
+def test_hidden_panel_placement_falls_back_when_geometry_application_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mutations: list[tuple[object, ...]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller.visible = True
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(
+        controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800)
+    )
+    monkeypatch.setattr(controller, "_apply_geometry_without_showing", lambda *_args: False)
+
+    controller._place_window_on_ui_thread()
+
+    assert mutations == [("resize", 380, 400), ("move", 608, 388)]
+
+
+@pytest.mark.parametrize("positioned_this_show", [False, True])
+def test_panel_placement_skips_unchanged_native_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    positioned_this_show: bool,
+) -> None:
+    mutations: list[tuple[object, ...]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=608,
+        y=388,
+        native=SimpleNamespace(Left=608, Top=388, Width=380, Height=400),
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller._content_height = 400
+    controller._positioned_this_show = positioned_this_show
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(
+        controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800)
+    )
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 1.0)
+    monkeypatch.setattr(
+        controller,
+        "_apply_geometry_without_showing",
+        lambda *_args: mutations.append(("SetWindowPos",)),
+    )
+
+    controller._place_window_on_ui_thread()
+
+    assert mutations == []
+    assert controller._positioned_this_show is True
+
+
+@pytest.mark.parametrize(
+    "native_geometry",
+    [
+        (607, 388, 380, 400),
+        (608, 388, 379, 400),
+    ],
+)
+def test_visible_panel_placement_applies_changed_native_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    native_geometry: tuple[int, int, int, int],
+) -> None:
+    mutations: list[tuple[object, ...]] = []
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=608,
+        y=388,
+        native=SimpleNamespace(
+            Left=native_geometry[0],
+            Top=native_geometry[1],
+            Width=native_geometry[2],
+            Height=native_geometry[3],
+        ),
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller._content_height = 400
+    controller._positioned_this_show = True
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(
+        controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800)
+    )
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: 1.0)
+
+    controller._place_window_on_ui_thread()
+
+    assert mutations == [("resize", 380, 400), ("move", 608, 388)]
+
+
+def test_hidden_panel_placement_without_native_geometry_still_applies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mutations: list[tuple[object, ...]] = []
+
+    def apply_geometry(width: int, height: int, x: int, y: int) -> bool:
+        mutations.append(("SetWindowPos", width, height, x, y))
+        return True
+
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        x=0,
+        y=0,
+        resize=lambda width, height: mutations.append(("resize", width, height)),
+        move=lambda x, y: mutations.append(("move", x, y)),
+    )
+    controller._content_height = 400
+    monkeypatch.setattr(controller, "_working_area", lambda: (0, 0, 1000, 800))
+    monkeypatch.setattr(
+        controller, "_work_area_for_point", lambda _point: (0, 0, 1000, 800)
+    )
+    monkeypatch.setattr(
+        controller,
+        "_apply_geometry_without_showing",
+        apply_geometry,
+    )
+
+    controller._place_window_on_ui_thread()
+
+    assert mutations == [("SetWindowPos", 380, 400, 608, 388)]
+
+
+@pytest.mark.parametrize(
+    ("scale", "expected"),
+    [
+        (1.0, (100, 20, 340, 400)),
+        (2.5, (250, 50, 850, 1000)),
+    ],
+)
+def test_geometry_without_showing_converts_logical_to_physical_pixels(
+    monkeypatch: pytest.MonkeyPatch,
+    scale: float,
+    expected: tuple[int, int, int, int],
+) -> None:
+    calls: list[tuple[object, ...]] = []
+
+    def set_window_pos(*args: object) -> bool:
+        calls.append(args)
+        return True
+
+    user32 = SimpleNamespace(SetWindowPos=set_window_pos)
+    controller = wintray._WindowsTrayController(mock=True, interval=60)
+    controller.window = SimpleNamespace(
+        native=SimpleNamespace(Handle=SimpleNamespace(ToInt32=lambda: 123))
+    )
+    monkeypatch.setattr(wintray, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(ctypes, "windll", SimpleNamespace(user32=user32), raising=False)
+    monkeypatch.setattr(controller, "_window_dpi_scale", lambda: scale)
+
+    result = controller._apply_geometry_without_showing(340, 400, 100, 20)
+
+    assert result is True
+    assert calls == [(123, None, *expected, 0x0014)]
+
+
 def test_physical_dpi_scaled_screens_are_converted_to_logical_coordinates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ui/html_report.py
+++ b/ui/html_report.py
@@ -30,6 +30,7 @@ from analyzer.reporter import (
 
 from i18n import _t as _i18n_t, packaged_resource_path
 from usage_common.usage_lang import detect_lang
+from usage_common.subprocess_utils import hidden_console_kwargs
 from ui.report_charts import render_share_bar, render_trend_bar
 from ui.report_scripts import HTML_TO_IMAGE_UMD, REPORT_JS_TEMPLATE, REPORT_THEME_INIT_JS
 from ui.report_styles import REPORT_CSS
@@ -1202,7 +1203,12 @@ def save_and_open(
     path.chmod(0o600)
     if out_path is None:
         if sys.platform == "darwin":
-            subprocess.run(["/usr/bin/open", str(path.resolve())], check=False)
+            subprocess.run(
+                ["/usr/bin/open", str(path.resolve())],
+                check=False,
+                stdin=subprocess.DEVNULL,
+                **hidden_console_kwargs(),
+            )
         else:
             webbrowser.open(path.resolve().as_uri())
     return display_path

--- a/usage_common/subprocess_utils.py
+++ b/usage_common/subprocess_utils.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 lollapalooza <https://github.com/aqua5230>
+#
+# Part of "usage". Free software licensed under the GNU Affero General Public
+# License v3.0 only; see the LICENSE file for full terms and the warranty disclaimer.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TypedDict
+
+
+class _HiddenConsoleKwargs(TypedDict, total=False):
+    creationflags: int
+
+
+def hidden_console_kwargs() -> _HiddenConsoleKwargs:
+    if sys.platform == "win32":
+        return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0)}
+    return {}

--- a/usage_session_resume.py
+++ b/usage_session_resume.py
@@ -44,9 +44,19 @@ import tempfile
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
-__version__ = "1.7"
+__version__ = "1.8"
+
+
+class _HiddenConsoleKwargs(TypedDict, total=False):
+    creationflags: int
+
+
+def hidden_console_kwargs() -> _HiddenConsoleKwargs:
+    if sys.platform == "win32":
+        return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0)}
+    return {}
 
 
 def _configure_windows_utf8_output() -> None:
@@ -381,6 +391,8 @@ def _git_dirty(cwd: str) -> tuple[str, int, list[str]] | None:
             timeout=2,
             encoding="utf-8",
             check=False,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
         if branch_proc.returncode != 0:
             return None
@@ -394,6 +406,8 @@ def _git_dirty(cwd: str) -> tuple[str, int, list[str]] | None:
             timeout=2,
             encoding="utf-8",
             check=False,
+            stdin=subprocess.DEVNULL,
+            **hidden_console_kwargs(),
         )
         if status_proc.returncode != 0:
             return None

--- a/usage_statusline_forwarder.py
+++ b/usage_statusline_forwarder.py
@@ -16,12 +16,22 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
-__version__ = "1.0"
+__version__ = "1.1"
 TIMEOUT_SECONDS = 5
 HOOK_DIR = os.path.expanduser("~/.claude")
 SELF_NAME = "usage-statusline-forwarder.py"
+
+
+class _HiddenConsoleKwargs(TypedDict, total=False):
+    creationflags: int
+
+
+def hidden_console_kwargs() -> _HiddenConsoleKwargs:
+    if sys.platform == "win32":
+        return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0)}
+    return {}
 
 
 def _configure_windows_utf8_output() -> None:
@@ -52,6 +62,7 @@ def _run_hook(py: str, hook: str, raw: str) -> str:
             check=False,
             capture_output=True,
             timeout=TIMEOUT_SECONDS,
+            **hidden_console_kwargs(),
         )
     except (subprocess.TimeoutExpired, OSError, UnicodeDecodeError):
         return ""

--- a/wintray/app.py
+++ b/wintray/app.py
@@ -984,6 +984,35 @@ class _WindowsTrayController:
                 return None
         return dpi / 96.0 if dpi > 0 else None
 
+    def _apply_geometry_without_showing(
+        self, width: int, height: int, x: int, y: int
+    ) -> bool:
+        if os.name != "nt" or self.window is None:
+            return False
+        scale = self._window_dpi_scale()
+        if scale is None:
+            return False
+        try:
+            windll: Any = getattr(ctypes, "windll")  # noqa: B009
+            user32 = windll.user32
+            native = self.window.native
+            handle = native.Handle
+            to_int32 = getattr(handle, "ToInt32", None)
+            hwnd = to_int32() if callable(to_int32) else int(handle)
+            return bool(
+                user32.SetWindowPos(
+                    hwnd,
+                    None,
+                    int(round(x * scale)),
+                    int(round(y * scale)),
+                    int(round(width * scale)),
+                    int(round(height * scale)),
+                    0x0014,
+                )
+            )
+        except Exception:
+            return False
+
     def _working_area(self) -> tuple[int, int, int, int] | None:
         """Return the primary monitor work area in pywebview logical pixels."""
         screens = self._logical_screens()
@@ -1127,11 +1156,33 @@ class _WindowsTrayController:
         )
         width = int(round(fitted_width))
         height = int(round(fitted_height))
-        self.window.resize(width, height)
         position = anchor if anchor is not None else self._default_window_position(
             work_area, width, height
         )
-        self.window.move(*self._clamp_window_position(position, work_area, width, height))
+        x, y = self._clamp_window_position(position, work_area, width, height)
+        try:
+            native = self.window.native
+            current_geometry = (native.Left, native.Top, native.Width, native.Height)
+        except Exception:
+            current_geometry = None
+        if current_geometry is not None and all(
+            not isinstance(value, bool) and isinstance(value, int | float)
+            for value in current_geometry
+        ):
+            dpi_scale = self._window_dpi_scale()
+            if dpi_scale is not None:
+                target_geometry = tuple(
+                    int(round(value * dpi_scale)) for value in (x, y, width, height)
+                )
+                if tuple(int(round(value)) for value in current_geometry) == target_geometry:
+                    self._positioned_this_show = True
+                    return
+        geometry_applied = not self._positioned_this_show and (
+            self._apply_geometry_without_showing(width, height, x, y)
+        )
+        if not geometry_applied:
+            self.window.resize(width, height)
+            self.window.move(x, y)
         self._positioned_this_show = True
 
     def _dispatch_window_mutation(self, mutation: Callable[[], None]) -> None:


### PR DESCRIPTION
接續 #130 回報者在 v0.30.13 的重測，把剩下兩個症狀修掉。兩個都是我們自己的 bug，不是 WebView2 的繪製時間差。

## 啟動時黑窗閃約 20 次

`usage.exe` 打包時不帶主控台，但專案所有 `subprocess` 呼叫都沒帶 `CREATE_NO_WINDOW`，Windows 因此替每個子行程建立又關閉一個主控台視窗。閃的次數等於 Claude 歷史紀錄裡不重複的專案目錄數——`resolve_project_name()` 對每個目錄跑一次 `git worktree list --porcelain`，每個行程快取一次，所以每次啟動都會重來。

新增 `usage_common/subprocess_utils.py` 提供共用的 `creationflags`，專案內所有子行程呼叫改走它，並補上缺漏的 `stdin=subprocess.DEVNULL`。

實測（父行程本身無主控台，各跑 10 次 git）：

```
baseline console windows: 0
10 git calls WITHOUT CREATE_NO_WINDOW -> peak console windows: 1
10 git calls WITH    CREATE_NO_WINDOW -> peak console windows: 0
```

### 兩支被複製出去的 hook 腳本

`usage_session_resume.py` 與 `usage_statusline_forwarder.py` 會被原樣複製到 `~/.claude/`，由系統 Python 獨立執行，那個環境沒有專案的任何模組，所以這兩支必須維持零專案相依，各自內聯一份等效實作。新增 `tests/test_hook_scripts_are_standalone.py`，用 `ast` 確保這幾支會被複製出去的腳本不引入專案模組——repo 內跑測試時 `sys.path` 剛好含專案根目錄，沒有這道防線抓不到。

### forwarder 的版號換新

`usage_statusline_forwarder.py` 內容改了，順帶發現它先前沒有版號換新機制：`_copy_forwarder_script()` 只在重裝或狀態異常時才被呼叫，副本落後時沒有任何路徑會換新。比照其他 hook 補上 `FORWARDER_VERSION` 與 `self_heal()` 的換新段落。`RESUME_HOOK_VERSION` 一併升到 1.8。

## 點系統匣時面板先閃在舊位置

pywebview 的 WinForms 後端在 `resize()` 與 `move()` 都帶 `SWP_SHOWWINDOW`，所以 `_place_window_on_ui_thread()` 裡那行 `resize()` 會在視窗還藏著時就把它顯示出來，而且是在上一次的座標上；隨後的 `move()` 才搬到正確位置，最後才輪到 `show()`。

1 毫秒取樣實測（t=0 為點擊系統匣）：

```
修正前
t=+13.76ms visible=False rect=(130, 130, 471, 1146)
t=+13.77ms visible=True  rect=(130, 130, 471, 1146)
t=+49.59ms visible=True  rect=(1567, 12, 1908, 1028)

修正後
t=+14.78ms visible=False rect=(993, 12, 1334, 1028)
t=+24.11ms visible=True  rect=(993, 12, 1334, 1028)
t=+250.02ms visible=True rect=(993, 12, 1333, 1028)
```

修正前在錯位置可見 36 毫秒，約兩個畫面幀。改成視窗還藏著時以單次 `SetWindowPos` 一起設定位置與大小、且不帶 `SWP_SHOWWINDOW`，顯示交由既有的 `show()` 路徑。取不到原生視窗或非 Windows 時退回原本的 `resize()` + `move()`，行為不變。

另外在套用幾何前先比對目前的實體像素幾何，完全相同就整個跳過，避免 `_apply_content_height_now()` 在內容高度沒變時仍做一次無謂的原生呼叫。修正後 +250ms 那次 1 像素寬度變化是面板載入後回報真實高度、尺寸收斂，不是錯置。

## 驗證

- `ruff check --exclude release-win .` 全過
- `mypy . --exclude release-win` 215 個檔案無問題
- `pytest -q` 1529 passed, 5 skipped, 0 failed（新增 36 支）
- 兩支 hook 腳本複製到 repo 外、用系統 Python 實際執行過，不再噴 `ModuleNotFoundError`
- 重新打包 `dist\usage-windows\usage.exe` 並實機取樣驗證

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMhC6TAmanmqJreL3ky87g
